### PR TITLE
add virtual environment setup and gulp task for building sphinx docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Website for EFF's CertBot project. Uses Jekyll for static site generation.
 2. `gem install jekyll` (requires v3.0 or higher)
 3. `sudo npm install gulp -g`
 4. `npm install`
+5. `./_docs.sh depend`
 
 ### Run
 To *watch* for changes and reload assets as needed via BrowserSync:

--- a/_docs.sh
+++ b/_docs.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+case "$1" in
+  "depend" )
+    cd _docs
+    ./letsencrypt-auto-source/letsencrypt-auto --os-packages-only
+    ./tools/venv.sh
+    ;;
+  "install" )
+    cd _docs
+    source ./venv/bin/activate
+    make -C docs clean html
+    ;;
+esac

--- a/_gulp/index.js
+++ b/_gulp/index.js
@@ -6,6 +6,6 @@ tasks.forEach(function(task) {
   require('./tasks/' + task);
 });
 
-gulp.task('watch', ['json-instructions', 'css', 'js', 'jekyll:watch', 'serve']);
-gulp.task('build', ['json-instructions', 'css', 'js', 'jekyll:build']);
+gulp.task('watch', ['json-instructions', 'css', 'js', 'jekyll:watch', 'docs:install', 'serve']);
+gulp.task('build', ['json-instructions', 'css', 'js', 'jekyll:build', 'docs:install']);
 

--- a/_gulp/tasks/docs.js
+++ b/_gulp/tasks/docs.js
@@ -1,0 +1,19 @@
+var gulp = require('gulp'),
+    child = require('child_process'),
+    git = require('gulp-git'),
+    del = require('del');
+
+gulp.task('docs:make', [], function (cb) {
+  return child.spawn('./_docs.sh', ['install'], {stdio: 'inherit', cwd: '.'})
+    .on('close', function(err) {
+      cb(err);
+    });
+});
+
+gulp.task('docs:install', ['docs:make'], function (cb) {
+  gulp.src(['./_docs/docs/_build/html/**'], {base: './_docs/docs/_build/html/'})
+    .pipe(gulp.dest('./_site/docs'))
+    .on('end', function(err) {
+      cb(err);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "webpack-require": "0.0.16"
   },
   "dependencies": {
+    "del": "^2.2.0",
+    "gulp-git": "^1.7.1",
     "jquery": "^2.2.3",
     "lodash": "^4.11.1",
     "mustache": "^2.2.1"


### PR DESCRIPTION
This commit adds a command for setting up the python venv and a gulp task for building the sphinx docs.

Hopefully it works elsewhere besides my virtualbox...

@todo figure out how to build the sphinx docs with a custom theme, for example either a custom build script (as readthedocs.org uses) or patching letsencrypt to use our theme, https://github.com/mfb/letsencrypt/tree/sphinx-theme
