### PR TITLE
Fix css bugs and tagline link

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -4,7 +4,7 @@
   <a href="/"><img class="logo" src="/images/certbot-logo-1A.svg" alt="Certbot"></a>
 
   <h1>Automatically enable HTTPS on your website with EFF's Certbot, deploying
-  <a href="https://certbot.eff.org">Let's Encrypt</a> certificates.</h1>
+  <a href="https://letsencrypt.org/" target="_blank" rel="noreferrer">Let's Encrypt</a> certificates.</h1>
 <!--   <h2>Certbot is the easiest way to get Let's
   Encrypt certificates; it can optionally autoconfigure HTTPS for you, too</h2> -->
 

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -57,7 +57,7 @@ header.hero {
     font-size: 1.6em;
     font-family: 'Roboto';
     font-weight: 400;
-    line-height: 1em;
+    line-height: 1.3em;
 
     a:visited {
         color: #838383;

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -1,6 +1,6 @@
 
 header.hero {
-  padding-top: 14em;
+  padding-top: 11.5em;
   @include susy-breakpoint($md) {
     padding-top: 5em;
   }
@@ -10,8 +10,10 @@ header.hero {
   display: block;
   width: 100%;
   height: 100vh;
+  min-height: 500px;
   @include susy-breakpoint($md) {
     height: 420px;
+    min-height: 0;
   }
   overflow: hidden;
   display: block;
@@ -56,7 +58,7 @@ header.hero {
     font-family: 'Roboto';
     font-weight: 400;
     line-height: 1em;
-    
+
     a:visited {
         color: #838383;
     }
@@ -83,7 +85,7 @@ header.hero {
     }
     font-family: 'Roboto Slab';
     font-weight: 200;
-   
+
     margin: 0;
     padding: 0;
     margin-top: -2.5em;


### PR DESCRIPTION
-Link tagline to letsencrypt website - #32 
-Increase line height of tagline on mobile
-Fix a bug where the instruction widget dropdown menus don't appear on very short viewports (ex. mobile landscape)