### PR TITLE
Ensure gulp exits with nonzero code on fail and encapsulate test command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 script:
   - gulp build
-  - htmlproofer ./_site --empty-alt-ignore true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/using.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html --allow-hash-href true
+  - npm test
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: node_js
 node_js:
   - 4.4.0
 
+addons:
+  apt:
+    packages:
+      - texlive
+      - texlive-latex-extra
+
 before_install:
   - rvm install 2.2.1
 
@@ -10,11 +16,8 @@ install:
   - npm install
   - gem install jekyll
   - gem install html-proofer
-  - git submodule init
-  - git submodule update
   - pip install virtualenv
   - ./_docs.sh depend
-  - sudo apt-get install texlive texlive-latex-extra
 
 script:
   - gulp build

--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ gem install html-proofer
 
 To run the tests:
 ```
-htmlproofer ./_site --empty-alt-ignore true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/using.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html --allow-hash-href true
+npm test
 ```
 (Files with known issues are ignored.)

--- a/_gulp/tasks/css.js
+++ b/_gulp/tasks/css.js
@@ -20,11 +20,13 @@ gulp.task('css', ['css:clean'], (done) => {
   return gulp.src(config.css.src)
     .pipe(env.development(sourcemaps.init()))
     .pipe(globbing({
-        extensions: ['.scss']
+      extensions: ['.scss']
     }))
-    .pipe(sass().on('error', sass.logError))
+    .pipe(env.development(sass())
+      .on('error', sass.logError))
+    .pipe(env.production(sass()))
     .pipe(autoprefixer({
-        browsers: ['last 2 version']
+      browsers: ['last 2 version']
     }))
     .pipe(env.development(sourcemaps.write('.')))
     .pipe(gulp.dest(config.css.dest))

--- a/_gulp/tasks/js.js
+++ b/_gulp/tasks/js.js
@@ -24,7 +24,8 @@ config.webpack = {
     new webpack.webpack.optimize.UglifyJsPlugin({
       compress: { warnings: false }
     })
-  ] : []
+  ] : [],
+  bail: env.production()
 }
 
 gulp.task('js', ['js:clean'], (done) => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gulp build certbot.",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "htmlproofer ./_site --empty-alt-ignore true --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html --allow-hash-href true"
   },
   "dependencies": {
     "browser-sync": "^2.11.2",


### PR DESCRIPTION
-In production builds, gulp now exits all tasks with a nonzero code on fail (resolves #106)
-The lengthy test command is encapsulated in "npm test" now (progress toward #104)