### PR TITLE
Update package names for Gentoo

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -109,15 +109,12 @@ module.exports = function(context) {
   gentoo_install = function() {
     template = "gentoo";
 
-    context.package = "letsencrypt";
-    context.base_command = "letsencrypt";
-    context.base_package = "app-crypt/letsencrypt";
+    context.package = "certbot";
+    context.base_command = "certbot"
+    context.base_package = "app-crypt/certbot";
     context.cbauto = false;
     if (context.webserver == "apache") {
-      context.package = "letsencrypt-apache";
-    }
-    if (context.webserver == "nginx" && context.advanced) {
-      context.package = "letsencrypt-nginx";
+      context.package = "certbot-apache";
     }
   }
 


### PR DESCRIPTION
update package names to reflect those changes done in the gentoo portage tree

Also there is no package called ` {certbot,letsencrypt}-nginx`

```
$ eix certbot
* app-crypt/certbot
     Available versions:  ~0.6.0 **9999 {test PYTHON_TARGETS="python2_7"}
     Installed versions:  0.5.0(21:35:42 19/04/16)(-test PYTHON_TARGETS="python2_7")
     Homepage:            https://github.com/certbot/certbot https://letsencrypt.org/
     Description:         Let's encrypt client to automate deployment of X.509 certificates

* app-crypt/certbot-apache
     Available versions:  **9999 {test PYTHON_TARGETS="python2_7"}
     Homepage:            https://github.com/certbot/certbot https://letsencrypt.org/
     Description:         Apache plugin for certbot (Let's Encrypt Client)

Found 2 matches
```
