### PR TITLE
FreeBSD port is now named Certbot

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -157,7 +157,7 @@ module.exports = function(context) {
 
     context.base_command = "letsencrypt";
     if (context.distro == "freebsd"){
-      context.portcommand = "py-letsencrypt";
+      context.portcommand = "py-certbot";
       context.package = "pkg install py27-letsencrypt";
     }
     if (context.distro == "opbsd"){


### PR DESCRIPTION
https://www.freebsd.org/cgi/ports.cgi?query=certbot&stype=all

Although it appears the package is still named letsencrypt (and is stuck on 0.4.1).