### PR TITLE
Update package name for FreeBSD

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -155,10 +155,10 @@ module.exports = function(context) {
   bsd_install = function() {
     template = "bsd"
 
-    context.base_command = "letsencrypt";
+    context.base_command = "certbot";
     if (context.distro == "freebsd"){
       context.portcommand = "py-certbot";
-      context.package = "pkg install py27-letsencrypt";
+      context.package = "pkg install py27-certbot";
     }
     if (context.distro == "opbsd"){
       context.portcommand = "letsencrypt/client";


### PR DESCRIPTION
The package name was changed to py27-certbot recently:
https://www.freshports.org/security/py-certbot/

The base command for all FreeBSD packages is now "certbot".

Tested on a clean image of FreeBSD 10.3.