### PR TITLE
Don't suggest the apache plugin on *BSD

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -169,6 +169,11 @@ module.exports = function(context) {
       context.package = "pkg_add letsencrypt";
       context.base_command = "letsencrypt";
     }
+
+    // The Apache plugin isn't packaged for BSD yet
+    if (context.webserver == "apache") {
+      context.webserver = "other"
+    }
   }
 
   macos_install = function() {


### PR DESCRIPTION
According to http://svnweb.freebsd.org/ports/head/security/py-certbot/pkg-message?view=markup, FreeBSD will be getting a separate `security/py-letsencrypt-apache` package in the future, but the apache plugin is not currently included.

OpenBSD packaging plans are unclear.