### PR TITLE
Reorder Dockerfile for speed and fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - texlive-latex-extra
 
 before_install:
-  - rvm install 2.2.1
+  - rvm install 2.2.2
 
 install:
   - npm install gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,19 @@ ENV NODE_ENV production
 ENV RUBY_VERSION 2.2.2
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true
 
-# Install docs dependencies
-COPY _docs/ ./_docs
-COPY _docs.sh ./
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    texlive \
-    texlive-latex-extra
-RUN ./_docs.sh depend
+# Set UTF-8 character encoding
+RUN apt-get update && apt-get install locales -y
+RUN echo dpkg-reconfigure -f noninteractive tzdata && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL C.UTF-8
+
+# need rsync for deploy script
+RUN apt-get install rsync -y
 
 # Install ruby and dependencies
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
@@ -28,19 +33,14 @@ COPY package.json ./
 RUN npm install gulp -g
 RUN npm install
 
-# need rsync for deploy script
-RUN apt-get install rsync -y
-
-# Set UTF-8 character encoding
-RUN apt-get install locales -y
-RUN echo dpkg-reconfigure -f noninteractive tzdata && \
-    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL C.UTF-8
+# Install docs dependencies
+COPY _docs/ ./_docs
+COPY _docs.sh ./
+RUN apt-get install -y --no-install-recommends \
+    texlive \
+    texlive-latex-extra
+RUN ./_docs.sh depend
+RUN ./_docs.sh install
 
 COPY _data ./_data
 COPY _faq_entries ./_faq_entries


### PR DESCRIPTION
Move things like building `ruby` and installing `jekyll` and `gulp` higher in the `Dockerfile` so they can be cached between website updates.
