### PR TITLE
Remove/fix EPEL instructions on CentOS/RHEL 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - texlive-latex-extra
 
 before_install:
-  - rvm install 2.2.1
+  - rvm install 2.2.2
 
 install:
   - npm install gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,19 @@ ENV NODE_ENV production
 ENV RUBY_VERSION 2.2.2
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true
 
-# Install docs dependencies
-COPY _docs/ ./_docs
-COPY _docs.sh ./
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    texlive \
-    texlive-latex-extra
-RUN ./_docs.sh depend
+# Set UTF-8 character encoding
+RUN apt-get update && apt-get install locales -y
+RUN echo dpkg-reconfigure -f noninteractive tzdata && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL C.UTF-8
+
+# need rsync for deploy script
+RUN apt-get install rsync -y
 
 # Install ruby and dependencies
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
@@ -28,19 +33,14 @@ COPY package.json ./
 RUN npm install gulp -g
 RUN npm install
 
-# need rsync for deploy script
-RUN apt-get install rsync -y
-
-# Set UTF-8 character encoding
-RUN apt-get install locales -y
-RUN echo dpkg-reconfigure -f noninteractive tzdata && \
-    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL C.UTF-8
+# Install docs dependencies
+COPY _docs/ ./_docs
+COPY _docs.sh ./
+RUN apt-get install -y --no-install-recommends \
+    texlive \
+    texlive-latex-extra
+RUN ./_docs.sh depend
+RUN ./_docs.sh install
 
 COPY _data ./_data
 COPY _faq_entries ./_faq_entries

--- a/_scripts/instruction-widget/data/inputs.json
+++ b/_scripts/instruction-widget/data/inputs.json
@@ -89,9 +89,15 @@
             "version": "23"
         },
         {
-            "name": "CentOS/RHEL 6",
-            "id": "centosrhel6",
+            "name": "CentOS 6",
+            "id": "centos6",
             "distro": "centos",
+            "version": "6"
+        },
+        {
+            "name": "RHEL 6",
+            "id": "centosrhel6",
+            "distro": "rhel",
             "version": "6"
         },
         {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -48,7 +48,7 @@ module.exports = function(context) {
     else if (context.distro == "fedora" && context.version > 22){
       fedora_install();
     }
-    else if (context.distro == "centos") {
+    else if (context.distro == "centos" || context.distro == "rhel") {
       centos_install();
     }
     else if (context.distro == "macos") {
@@ -77,6 +77,7 @@ module.exports = function(context) {
 
     if (context.version < 7) {
       context.base_command = "./path/to/certbot-auto"
+      context.epel_auto = (context.distro == "centos")
       context.packaged = false
     } else {
       context.base_command = "certbot"

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -9,11 +9,13 @@ $ sudo yum install {{package}}
 </pre>
 {{/packaged}}
 {{^packaged}}
+{{^epel_auto}}
+<p>
 Not all of Certbot's dependencies are available in the standard repositories.
-To use Certbot, you must first enable the EPEL (Extra Packages for Enterprise Linux)
-repository by running
-<pre>
-$ sudo yum install epel-release
-</pre>
+To use Certbot, you must first <a
+href="https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F">
+enable the EPEL (Extra Packages for Enterprise Linux) repository</a>.
+</p>
+{{/epel_auto}}
 {{>auto}}
 {{/packaged}}


### PR DESCRIPTION
~~Blocked on certbot/certbot#3651 to pass tests.~~

Built on #162.

I used the id "centosrhel6" for RHEL 6 to prevent breaking links like https://certbot.eff.org/#centosrhel6-other. For these links, it is better to provide instructions for enabling EPEL even if `certbot-auto` can do it for you (CentOS 6 users) than to provide no instructions on how to do it when you have to do it manually (RHEL 6 users).
