### PR TITLE
FAQ update: Answer for CSR is no longer misleading.

### DIFF
--- a/_faq_entries/11-CSR.md
+++ b/_faq_entries/11-CSR.md
@@ -3,4 +3,4 @@ title:  "Can I use an existing private key or Certificate Signing Request (CSR) 
 weight: 11
 ---
 
-Yes, you can obtain a certificate for an existing private key (if the key is an appropriate type and size), and, if you want, you can use an existing CSR.
+Yes. You can obtain a certificate for an existing CSR, which means you may generate your own CSR using your own private key. However, certbot will not accept a private key as input and generate a CSR for you.


### PR DESCRIPTION
Previously, the answer in the FAQ misleads a reader to believe the certbot will accept a private key as input, and that providing a CSR as input is optional. In fact, providing CSR is the only means of using your own private key.