### PR TITLE
Update Ubuntu install instructions

### DIFF
--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -4,6 +4,7 @@
 </p>
 
 <pre>
+$ sudo apt-get install software-properties-common
 $ sudo add-apt-repository ppa:certbot/certbot
 $ sudo apt-get update
 $ sudo apt-get install {{package}} {{backports_flag}}


### PR DESCRIPTION
[Apparently](https://community.letsencrypt.org/t/could-not-bind-tcp-port-443-because-it-is-already-in-use-by-another-process-on-this-system-such-as-a-web-server-please-stop-the-program-in-question-and-then-try-again/30905/5?u=jmorahan) `add-apt-repository` isn't always available by default?