### PR TITLE
use sentry.eff.org for crash reporting

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
 
     {% if page.js %}
       {% for js_file in page.js %}
-        <script src='/js/{{ js_file }}.js' type="text/javascript"></script>
+        <script src='/js/{{ js_file }}.js' type="text/javascript" defer="defer"></script>
       {% endfor %}
     {% endif %}
 </head>

--- a/_scripts/main.js
+++ b/_scripts/main.js
@@ -18,6 +18,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+var Raven = require('raven-js');
+
+(function (Raven) {
+
+  'use strict';
+
+  Raven.config('https://caa5edd9fc344ff69a3e0bd4c05a5a91@sentry.eff.org/20').install();
+
+})(Raven);
+
 (function() {
 
   var hamburger = document.getElementById('hamburger');

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "gulp-webpack": "^1.5.0",
     "gulp-zip": "^3.2.0",
     "hogan.js": "^3.0.2",
+    "jquery": "^2.2.3",
     "json-loader": "^0.5.4",
     "loader-utils": "^0.2.14",
+    "lodash": "^4.11.1",
+    "mustache": "^2.2.1",
     "mustache-loader": "^0.3.1",
+    "raven-js": "^3.14.2",
     "susy": "^2.2.12",
     "webpack": "^1.13.0",
-    "webpack-require": "0.0.16",
-    "jquery": "^2.2.3",
-    "lodash": "^4.11.1",
-    "mustache": "^2.2.1"
+    "webpack-require": "0.0.16"
   }
 }


### PR DESCRIPTION
We should report client-side exceptions to sentry.eff.org

This PR adds a new dependency, raven.js (the sentry client)