### PR TITLE
Expose nginx through documentation

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -199,10 +199,6 @@ module.exports = function(context) {
     template = "auto";
     context.cbauto = true
     context.base_command = "./path/to/certbot-auto";
-
-    if (context.webserver == "nginx") {
-      context.certonly = true;
-    }
   }
 
   return {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -138,7 +138,7 @@ module.exports = function(context) {
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.certonly = true;
+      context.package = "certbot-nginx";
     }
   }
 

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -45,7 +45,6 @@ module.exports = function(context) {
       bsd_install();
     }
     else if (context.distro == "arch"){
-      context.certonly = "true";
       arch_install();
     }
     else if (context.distro == "fedora" && context.version > 22){
@@ -88,6 +87,8 @@ module.exports = function(context) {
 
       if (context.webserver == "apache") {
         context.package = "python-certbot-apache";
+      } else if (context.webserver == "nginx") {
+        context.certonly = true;
       }
     }
   }
@@ -98,16 +99,19 @@ module.exports = function(context) {
     // Debian Jessie
     context.base_command = "certbot";
     context.cron_included = true;
+    context.package = "certbot";
+
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
-    } else {
-      context.package = "certbot"
+    } else if (context.webserver == "nginx") {
+      context.certonly = true;
     }
+
     // Debian Jessie backports.
     if (context.version == 8) {
       context.backports_flag = "-t jessie-backports";
     }
-    
+
   }
 
   ubuntu_install = function() {
@@ -116,6 +120,8 @@ module.exports = function(context) {
     context.package = "certbot"
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
+    } else if (context.webserver == "nginx") {
+      context.certonly = true;
     }
     // Debian Jessie, Ubuntu 16.10, or newer
     context.base_command = "certbot";
@@ -131,10 +137,13 @@ module.exports = function(context) {
     context.cbauto = false;
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
+    } else if (context.webserver == "nginx") {
+      context.certonly = true;
     }
   }
 
   arch_install = function() {
+    context.certonly = true;
     template = "arch";
     if (context.webserver == "apache" && context.advanced) {
         context.package = "certbot-apache";
@@ -154,6 +163,8 @@ module.exports = function(context) {
 
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
+    } else if (context.webserver == "nginx") {
+      context.certonly = true;
     }
   }
   // @todo: convert to template style
@@ -173,7 +184,9 @@ module.exports = function(context) {
 
     // The Apache plugin isn't packaged for BSD yet
     if (context.webserver == "apache") {
-      context.webserver = "other"
+      context.certonly = true;
+    } else if (context.webserver == "nginx") {
+      context.certonly = true;
     }
   }
 
@@ -186,6 +199,10 @@ module.exports = function(context) {
     template = "auto";
     context.cbauto = true
     context.base_command = "./path/to/certbot-auto";
+
+    if (context.webserver == "nginx") {
+      context.certonly = true;
+    }
   }
 
   return {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -143,15 +143,18 @@ module.exports = function(context) {
   }
 
   arch_install = function() {
-    context.certonly = true;
     template = "arch";
-    if (context.webserver == "apache" && context.advanced) {
+    context.package = "certbot"
+
+    if (context.webserver == "apache") {
+      context.certonly = true;
+      if (context.advanced) {
         context.package = "certbot-apache";
-    } else if (context.webserver == "nginx" && context.advanced) {
+      }
+    } else if (context.webserver == "nginx") {
         context.package = "certbot-nginx";
-    } else {
-        context.package = "certbot";
     }
+
     context.base_command = "certbot";
     context.base_package = "certbot";
   }

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -4,7 +4,8 @@ many platforms, and automates both obtaining and installing certs:
 </p>
 <pre>$ {{base_command}} --apache</pre>
 <p>
-If you're feeling more conservative and would like to make the changes to your
+Running this command will get a certificate for you and have Certbot edit your Apache configuration
+automatically to serve it. If you're feeling more conservative and would like to make the changes to your
 Apache configuration by hand, you can use the <tt>certonly</tt>
 subcommand:
 <pre>$ {{base_command}} --apache certonly</pre>

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -1,17 +1,33 @@
-{{> certonly}}
+<p>
+Certbot has an alpha-quality Nginx plugin, which is supported on
+many platforms, and automates both obtaining and installing certs:
+</p>
+<pre>$ {{base_command}} --nginx</pre>
+<p>
+If you're feeling more conservative and would like to make the changes to your
+Nginx configuration by hand, you can use the <tt>certonly</tt>
+subcommand:
+<pre>$ {{base_command}} --nginx certonly</pre>
 
 {{#advanced}}
-<h2>Experimental Nginx Plugin Support</h2>
-<blockquote>
-    There is a pre-alpha Nginx plugin that will automatically obtain and
-    install certs.  It is known to be buggy, so <b>you should only use it
-    after backing up your config</b> and if you are comfortable fixing
-    possible breakage.  On some
-    platforms there's a <tt>certbot-nginx</tt> or <tt>letsencrypt-nginx</tt>
-    or <tt>python-certbot-nginx</tt>
-    package you can install to get that plugin.  If not, you can <a
-    href="/docs/contributing.html#running-a-local-copy-of-the-client">follow
-    the developer instructions</a> to run Certbot with Nginx support from git
-    master.
-</blockquote>
+    <aside class="note">
+        <h4>Note:</h4>
+        <p>the Nginx plugin with <tt>certonly</tt> does the following:<br>
+        <ol>
+          <li>make temporary config changes<br>
+          (adding a new server block to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>)</li>
+          <li>performs a graceful reload</li>
+          <li>reverts all changes</li>
+          <li>performs another graceful reload</li>
+        </ol>
+        This appears to be a reliable process, but if you don't want Certbot
+        to touch your Nginx process or files in any way, you can use the
+        <a
+        href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+
+        </p></aside>
 {{/advanced}}
+
+To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
+</p>
+{{> renewal}}

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -4,7 +4,8 @@ many platforms, and automates both obtaining and installing certs:
 </p>
 <pre>$ {{base_command}} --nginx</pre>
 <p>
-If you're feeling more conservative and would like to make the changes to your
+Running this command will get a certificate for you and have Certbot edit your Nginx configuration
+automatically to serve it. If you're feeling more conservative and would like to make the changes to your
 Nginx configuration by hand, you can use the <tt>certonly</tt>
 subcommand:
 <pre>$ {{base_command}} --nginx certonly</pre>

--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -2,7 +2,7 @@
 <aside class="note">
 <h4>Note</h4>
 <p>
-For more extensive instructions on how to use Certbot on Arch linux you can refer to the documentation on the 
+For more extensive instructions on how to use Certbot on Arch linux you can refer to the documentation on the
 <a href="https://wiki.archlinux.org/index.php/Let%E2%80%99s_Encrypt">Arch wiki</a>
 </p>
 </aside>
@@ -14,9 +14,6 @@ For more extensive instructions on how to use Certbot on Arch linux you can refe
 {{>warning}}
 {{/apache}}
 
-{{#nginx}}
-{{>warning}}
-{{/nginx}}
 
 <pre>
 $ sudo pacman -S {{package}}


### PR DESCRIPTION
Expose Nginx for `certbot-auto` and Arch users. Otherwise, keep showing `certonly` instructions.