### PR TITLE
Make tests run in certbot-deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ COPY _docs.sh ./
 RUN apt-get install -y --no-install-recommends \
     texlive \
     texlive-latex-extra
+COPY .git ./.git
+COPY .gitmodules ./.gitmodules
 RUN ./_docs.sh depend
 RUN ./_docs.sh install
 
@@ -61,7 +63,5 @@ COPY favicon.ico ./favicon.ico
 COPY gulpfile.js ./gulpfile.js
 COPY index.html ./index.html
 COPY certbot-deploy ./certbot-deploy
-COPY .git ./.git
-COPY .gitmodules ./.gitmodules
 
 CMD ["bash"]

--- a/certbot-deploy
+++ b/certbot-deploy
@@ -15,7 +15,7 @@ cd $SOURCE_DOCS && \
   git checkout master && \
   git pull && \
   cd $SOURCE_DOCS && \
-  npm test && \
   gulp build --env production && \
+  npm test && \
   rsync -a -O --delete --exclude=".*" _site/ $COMPILED_DOCS && \
   echo "Certbot site built"


### PR DESCRIPTION
Turns out our `certbot-deploy` script doesn't actually run tests. I was confused why #225 failed given it was exactly what I just had done a release on. In playing with it, I found the following output:
```
Running ["ScriptCheck", "ImageCheck", "LinkCheck"] on ./_site on *.html... 


Checking 0 external links...
Ran on 0 files!


HTML-Proofer finished successfully.
```
We need to build the website before we can test it. This is what's done in [Travis](https://github.com/certbot/website/blob/master/.travis.yml#L22) as well.