### PR TITLE
Cache more in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,11 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL C.UTF-8
 
-# need rsync for deploy script
-RUN apt-get install rsync -y
+# need rsync for deploy script and texlive for building docs
+RUN apt-get install -y --no-install-recommends \
+    rsync \
+    texlive \
+    texlive-latex-extra
 
 # Install ruby and dependencies
 RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
@@ -36,9 +39,6 @@ RUN npm install
 # Install docs dependencies
 COPY _docs/ ./_docs
 COPY _docs.sh ./
-RUN apt-get install -y --no-install-recommends \
-    texlive \
-    texlive-latex-extra
 COPY .git ./.git
 COPY .gitmodules ./.gitmodules
 RUN ./_docs.sh depend

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ COPY _docs.sh ./
 RUN apt-get install -y --no-install-recommends \
     texlive \
     texlive-latex-extra
+COPY .git ./.git
+COPY .gitmodules ./.gitmodules
 RUN ./_docs.sh depend
 RUN ./_docs.sh install
 
@@ -61,7 +63,5 @@ COPY favicon.ico ./favicon.ico
 COPY gulpfile.js ./gulpfile.js
 COPY index.html ./index.html
 COPY certbot-deploy ./certbot-deploy
-COPY .git ./.git
-COPY .gitmodules ./.gitmodules
 
 CMD ["bash"]

--- a/certbot-deploy
+++ b/certbot-deploy
@@ -15,7 +15,7 @@ cd $SOURCE_DOCS && \
   git checkout master && \
   git pull && \
   cd $SOURCE_DOCS && \
-  npm test && \
   gulp build --env production && \
+  npm test && \
   rsync -a -O --delete --exclude=".*" _site/ $COMPILED_DOCS && \
   echo "Certbot site built"


### PR DESCRIPTION
Built on #226 so tests pass and to avoid merge conflicts. This PR simply moves the installation of `texlive` earlier in the Dockerfile, before we copy any local files that may have changed, to cache more between each build.