### PR TITLE
use brief package names on RHEL and Fedora

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -162,9 +162,6 @@ module.exports = function(context) {
   fedora_install = function() {
     template = "fedora";
     context.package = "certbot";
-    template = "fedora";
-    context.package = "certbot";
-    context.base_command = 
     context.base_command = "certbot";
 
     if (context.webserver == "apache") {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -86,9 +86,9 @@ module.exports = function(context) {
       context.packaged = true
 
       if (context.webserver == "apache") {
-        context.package = "python-certbot-apache";
+        context.package = "certbot-apache";
       } else if (context.webserver == "nginx") {
-        context.package = "python-certbot-nginx";
+        context.package = "certbot-nginx";
       }
     }
   }
@@ -162,12 +162,15 @@ module.exports = function(context) {
   fedora_install = function() {
     template = "fedora";
     context.package = "certbot";
+    template = "fedora";
+    context.package = "certbot";
+    context.base_command = 
     context.base_command = "certbot";
 
     if (context.webserver == "apache") {
-      context.package = "python-certbot-apache";
+      context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.package = "python-certbot-nginx";
+      context.package = "certbot-nginx";
     }
   }
   // @todo: convert to template style


### PR DESCRIPTION
Any of the python(2|3)?- prefixes may be used from release to release so let's use the [human-friendly Provides](
http://pkgs.fedoraproject.org/cgit/rpms/python-certbot-apache.git/tree/python-certbot-apache.spec?h=epel7&id=ba008026265153eaeb877d97b950c80f74eb6e41#n44) that [works everywhere](
http://pkgs.fedoraproject.org/cgit/rpms/python-certbot-apache.git/tree/python-certbot-apache.spec?id=e5b7d78cd4431703c33ac84d3ddee19f593fd74e#n44).

I believe the python- prefix doesn't work on RHEL because the spec relies on a magic `%python_provide` macro that is only defined in Fedora.