### PR TITLE
Use exact package names for CentOS/RHEL

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -86,9 +86,9 @@ module.exports = function(context) {
       context.packaged = true
 
       if (context.webserver == "apache") {
-        context.package = "certbot-apache";
+        context.package = "python2-certbot-apache";
       } else if (context.webserver == "nginx") {
-        context.package = "certbot-nginx";
+        context.package = "python2-certbot-nginx";
       }
     }
   }


### PR DESCRIPTION
These packages are installable with the `python2-` prefix.  I'm unsure whether the packages changed name and can't seem to find why the discrepency, but EPEL is currently using these names:  see https://mirror.aarnet.edu.au/pub/epel/7/x86_64/p/.