### PR TITLE
Fix building via gulp on node v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Website for [EFF's Certbot](https://certbot.eff.org/) project. Uses Jekyll for s
 ## Getting Started
 
 ### Install
-1. Install `ruby 2.0+`, `node`, and `npm 2.0+`.
+1. Install `ruby 2.0+`, `node 4.0+`, and `npm 2.0+`.
 2. `gem install jekyll` (requires v3.0 or higher)
 3. `sudo npm install gulp -g`
 4. `npm install`

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gulp-autoprefixer": "^3.1.0",
     "gulp-css-globbing": "^0.1.8",
     "gulp-environments": "^0.1.1",
-    "gulp-git": "^1.7.1",
+    "gulp-git": "^2.4.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",


### PR DESCRIPTION
Before this change, both ```gulp watch``` and ```gulp build``` fails with:
```
/home/yen/Projects/website/node_modules/require-dir/index.js:93
            if (!require.extensions.hasOwnProperty(ext)) {
                                    ^

TypeError: require.extensions.hasOwnProperty is not a function
    at requireDir (/home/yen/Projects/website/node_modules/require-dir/index.js:93:37)
    at Object.<anonymous> (/home/yen/Projects/website/node_modules/gulp-git/index.js:4:18)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/yen/Projects/website/_gulp/tasks/docs.js:3:11)
```

Bumping gulp-git to 2.3.2 or newer can fix this. Judging from [its changelog](https://github.com/stevelacy/gulp-git/releases), the only backward incompatibility in new gulp-git is:

> ```strip-bom-stream``` is es6 and will break on pre node v4

So I guess it's safe to bump that for the certbot website. After bumping gulp runs fine.

Environment: Arch Linux x86_64 with nodejs 8.1.3

Ref:
1. https://github.com/aseemk/requireDir/issues/45
2. https://github.com/stevelacy/gulp-git/issues/164