### PR TITLE
Add Debian Stretch to OS dropdown

### DIFF
--- a/_scripts/instruction-widget/data/inputs.json
+++ b/_scripts/instruction-widget/data/inputs.json
@@ -41,6 +41,12 @@
             "version": "8"
         },
         {
+            "name": "Debian 9 (stretch)",
+            "id": "debianstretch",
+            "distro": "debian",
+            "version": "9"
+        },
+        {
             "name": "Debian testing/unstable",
             "id": "debiantesting",
             "distro": "debian",


### PR DESCRIPTION
Adds Debian Stretch to the OS dropdown list. Since the instructions are identical to Debian Jessie (8), this was pretty straightforward.

![](http://ss.dan.cx/2017/07/Certbot_-_Google_Chrome_15-22.16.25.png)

Closes #252