### PR TITLE
move amazon note into a note

### DIFF
--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -6,6 +6,8 @@ Certbot, you must first <a
 href="https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F">
 enable the EPEL repository</a> and enable EPEL optional channel.
 </p>
+<aside class="note">
+<h4>Note:</h4>
 <p>
 If you are using ec2  you can enable optional channel by running:
 </p>
@@ -13,6 +15,7 @@ If you are using ec2  you can enable optional channel by running:
 $ yum -y install yum-utils
 $ yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional
 </pre>
+</aside>
 <p>
 After doing this, you can install Certbot by running:
 </p>


### PR DESCRIPTION
the amazon note is confusing, and I think it causes people to not click the first link to the EPEL instructions, so I've moved it into a note block