### PR TITLE
Make the right margin wider in the docs

### DIFF
--- a/_sass/theme.css
+++ b/_sass/theme.css
@@ -3715,6 +3715,7 @@ p {
   margin: 0;
   font-size: 16px;
   margin-bottom: 24px;
+  max-width: 800px;
 }
 
 h1 {

--- a/_sass/theme.css
+++ b/_sass/theme.css
@@ -4561,7 +4561,6 @@ div[class^='highlight'] pre {
 .wy-nav-content {
   padding: 1.618em 3.236em;
   height: 100%;
-  max-width: 800px;
   margin: auto;
 }
 


### PR DESCRIPTION
 * This makes the table at
   https://certbot.eff.org/docs/using.html#getting-certificates-and-choosing-plugins
   much more readable on many devices