### PR TITLE
add note about package aliases

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -64,6 +64,7 @@ module.exports = function(context) {
     partials.auto = require(TEMPLATE_PATH + "commonauto.html");
     partials.header = require(TEMPLATE_PATH + "header.html");
     partials.warning = require(TEMPLATE_PATH + "warning.html");
+    partials.packagealiasnote = require(TEMPLATE_PATH + "packagealiasnote.html");
 
     // Load and render the selected template.
     template = require(TEMPLATE_PATH + template + '.html');
@@ -86,11 +87,14 @@ module.exports = function(context) {
       context.base_command = "certbot"
       context.package = "certbot"
       context.packaged = true
+      context.python_prefix = "python2-"
 
       if (context.webserver == "apache") {
         context.package = "certbot-apache";
       } else if (context.webserver == "nginx") {
         context.package = "certbot-nginx";
+      } else {
+        context.python_prefix = null;
       }
     }
   }
@@ -163,11 +167,14 @@ module.exports = function(context) {
     template = "fedora";
     context.package = "certbot";
     context.base_command = "certbot";
+    context.python_prefix = "python3-";
 
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {
       context.package = "certbot-nginx";
+    } else {
+      context.python_prefix = null;
     }
   }
   // @todo: convert to template style

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -23,6 +23,7 @@ After doing this, you can install Certbot by running:
 <pre>
 $ sudo yum install {{package}}
 </pre>
+{{> packagealiasnote}}
 {{/packaged}}
 {{^packaged}}
 {{^epel_auto}}

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -6,3 +6,4 @@ Certbot is packaged for your OS, so to install it simply run the following comma
 <pre>
 $ sudo dnf install {{package}}
 </pre>
+{{> packagealiasnote}}

--- a/_scripts/instruction-widget/templates/install/packagealiasnote.html
+++ b/_scripts/instruction-widget/templates/install/packagealiasnote.html
@@ -1,0 +1,10 @@
+{{#python_prefix}}
+<aside class="note">
+<h4>Note:</h4>
+<p>
+This command will install the certbot packages corresponding to the system
+default Python interpreter, so the packages that are actually installed will
+contain a prefix like <code>{{python_prefix}}</code>.
+</p>
+</aside>
+{{/python_prefix}}


### PR DESCRIPTION
This satisfies the concerns in #263 without sacrificing forward-compatibility and
keeping things shorter to type and easier to remember.

The partial is added to Fedora and CentOS/RHEL where it currently applies, but
could be added to other distros where it is relevant.

The package name prefix used by each distro is defined in
{{python_prefix}}, and the note can be switched off by making that falsy. This
is done when just certbot is installed, since that isn't an alias.