### PR TITLE
suggest stretch backports and nginx

### DIFF
--- a/_scripts/instruction-widget/data/inputs.json
+++ b/_scripts/instruction-widget/data/inputs.json
@@ -50,7 +50,7 @@
             "name": "Debian testing/unstable",
             "id": "debiantesting",
             "distro": "debian",
-            "version": "9"
+            "version": "10"
         },
         {
             "name": "Debian (other)",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -123,6 +123,9 @@ module.exports = function(context) {
         context.package = "python-certbot-nginx";
       }
     }
+    if (context.version == 10 && context.webserver == "nginx") {
+      context.package = "python-certbot-nginx";
+    }
 
   }
 

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -108,16 +108,20 @@ module.exports = function(context) {
 
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
-    } else if (context.webserver == "nginx") {
-      context.package = "python-certbot-nginx";
     }
 
     // Jessie backports.
     if ((context.devuan && context.version == 1) || context.jessie) {
       context.backports_flag = "-t jessie-backports";
+      if (context.webserver == "nginx") {
+        context.certonly = true;
+      }
     }
     if (context.stretch) {
       context.backports_flag = "-t stretch-backports";
+      if (context.webserver == "nginx") {
+        context.package = "python-certbot-nginx";
+      }
     }
 
   }

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -98,6 +98,8 @@ module.exports = function(context) {
   debian_install = function() {
     template = "debian";
     context.devuan = context.distro == "devuan"
+    context.jessie = context.version == 8
+    context.stretch = context.version == 9
 
     // Debian Jessie
     context.base_command = "certbot";
@@ -107,12 +109,15 @@ module.exports = function(context) {
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.certonly = true;
+      context.package = "python-certbot-nginx";
     }
 
     // Jessie backports.
-    if ((context.devuan && context.version == 1) || context.version == 8) {
+    if ((context.devuan && context.version == 1) || context.jessie) {
       context.backports_flag = "-t jessie-backports";
+    }
+    if (context.stretch) {
+      context.backports_flag = "-t stretch-backports";
     }
 
   }

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -12,7 +12,7 @@ file</a>.
 {{/devuan}}
 {{^devuan}}
 First you'll have to follow the instructions <a
-href='http://backports.debian.org/Instructions/'>here</a> to enable the Jessie
+    href='http://backports.debian.org/Instructions/'>here</a> to enable the {{#jessie}}Jessie{{/jessie}}{{#stretch}}Stretch{{/stretch}}
 backports repo, if you have not already done so.
 {{/devuan}}
 Then run:

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -11,8 +11,7 @@ href='https://devuan.org/os/etc/apt/sources.list.d/devuan-stable-backports.list'
 file</a>.
 {{/devuan}}
 {{^devuan}}
-First you'll have to follow the instructions <a
-    href='http://backports.debian.org/Instructions/'>here</a> to enable the {{#jessie}}Jessie{{/jessie}}{{#stretch}}Stretch{{/stretch}}
+First you'll have to follow the instructions <a href='http://backports.debian.org/Instructions/'>here</a> to enable the {{#jessie}}Jessie{{/jessie}}{{#stretch}}Stretch{{/stretch}}
 backports repo, if you have not already done so.
 {{/devuan}}
 Then run:


### PR DESCRIPTION
addresses #283 until 0.19.0 is in stretch sloppy
this will give stretch users access to the nginx plugin: https://packages.debian.org/jessie-backports/python-certbot-nginx