### PR TITLE
Remove no-self-upgrade from renewal instructions

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -137,7 +137,6 @@ module.exports = function(context) {
     context.package = "certbot";
     context.base_command = "certbot";
     context.base_package = "app-crypt/certbot";
-    context.cbauto = false;
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {
@@ -204,7 +203,6 @@ module.exports = function(context) {
 
   auto_install = function() {
     template = "auto";
-    context.cbauto = true
     context.base_command = "./path/to/certbot-auto";
   }
 

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -22,7 +22,7 @@ If that appears to be working correctly, you can arrange for automatic renewal
 by adding a <tt>cron</tt> or <tt>systemd</tt> job which runs the
 following:<br>
 
-<pre>{{base_command}} renew {{#cbauto}}--no-self-upgrade{{/cbauto}}</pre>
+<pre>{{base_command}} renew</pre>
 {{/cron_included}}
 
 <p>More detailed information and options about renewal can be found in <a


### PR DESCRIPTION
It's extremely rare for `certbot-auto`'s autoupdate mechanism to fail and by including this flag, users are excluded from bug fixes, security updates, etc.

Let's remove it from the instructions now that the script is much more thoroughly tested.