### PR TITLE
ppa: drop yakkety + zesty as they hit EOL

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -59,18 +59,6 @@
             "version": "0"
         },
         {
-            "name": "Ubuntu 17.04 (zesty)",
-            "id": "ubuntutzesty",
-            "distro": "ubuntu",
-            "version": "17.04"
-        },
-        {
-            "name": "Ubuntu 16.10 (yakkety)",
-            "id": "ubuntutyakkety",
-            "distro": "ubuntu",
-            "version": "16.10"
-        },
-        {
             "name": "Ubuntu 16.04 (xenial)",
             "id": "ubuntuxenial",
             "distro": "ubuntu",


### PR DESCRIPTION
Note that these also had a c+p error (the `t` appears to come from `ubuntutrusty`), but as they're EOL, there's no reason to maintain that...