### PR TITLE
Update Apache and Nginx instructions

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -22,6 +22,7 @@ module.exports = function(context) {
   html = function() {
 
     context.cron_included = false;
+    context.installer_http01 = true;
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
     if (context.webserver == "plesk" || context.distro == "nonunix" ||
@@ -113,12 +114,14 @@ module.exports = function(context) {
     // Jessie backports.
     if ((context.devuan && context.version == 1) || context.jessie) {
       context.backports_flag = "-t jessie-backports";
+      context.installer_http01 = false;
       if (context.webserver == "nginx") {
         context.certonly = true;
       }
     }
     if (context.stretch) {
       context.backports_flag = "-t stretch-backports";
+      context.installer_http01 = false;
       if (context.webserver == "nginx") {
         context.package = "python-certbot-nginx";
       }
@@ -149,6 +152,7 @@ module.exports = function(context) {
     context.package = "certbot";
     context.base_command = "certbot";
     context.base_package = "app-crypt/certbot";
+    context.installer_http01 = false;
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -55,15 +55,17 @@ many platforms, and automates certificate installation.
     If you're not serving files out of a directory on the server, you can
     temporarily stop your server while you obtain the certificate, however,
     you'll have to configure Apache to use the certificate yourself.
-    The command to do this would look like:
+    The command to do this would something look like:
     </p>
     <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "apachectl -k stop" --post-hook "apachectl -k start"</pre>
     <p>
-    By using a command with hooks like this, if you automate renewal as
-    described below, Certbot will automatically stop and start Apache when you
-    need to renew your certificates. If you configure Apache to use the
-    symlinks in the "live" directory as instructed by Certbot, Apache will
-    automatically begin using any renewed certificates.
+    If you usually use a command like <tt>systemctl</tt> or
+    <tt>service</tt> to start and stop Apache, you should use those commands
+    instead in the hooks above. By using a command with hooks like this, if
+    you automate renewal as described below, Certbot will automatically stop
+    and start Apache when you need to renew your certificates. If you configure
+    Apache to use the symlinks in the "live" directory as instructed by
+    Certbot, Apache will automatically begin using any renewed certificates.
     </p>
 {{/installer_http01}}
 

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -16,8 +16,10 @@ many platforms, and automates certificate installation.
             <h4>Note:</h4>
             <p>the apache plugin with <tt>certonly</tt> does the following:<br>
             <ol>
-              <li>make temporary config changes<br>
-              (adding a new vhost to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
+              <li>make temporary config changes<br> (adding a new virtual host
+              to pass an <a
+              href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME
+              Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
               <li>performs a graceful reload</li>
               <li>reverts all changes</li>
               <li>performs another graceful reload</li>
@@ -25,7 +27,8 @@ many platforms, and automates certificate installation.
             This appears to be a reliable process, but if you don't want Certbot
             to touch your Apache process or files in any way, you can use the
             <a
-            href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+            href="https://certbot.eff.org/docs/using.html#webroot">webroot
+            plugin</a> instead.
 
             </p></aside>
     {{/advanced}}
@@ -38,10 +41,11 @@ many platforms, and automates certificate installation.
     href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
     </p>
     <p>
-    We released a new version of Certbot to work around this, but it's not been
-    packaged by your OS yet. If you have to obtain a certificate and cannot
-    wait, you have a couple of options. If you're serving files for that domain
-    out of a directory on that server, you can run the following command:
+    We released a new version of Certbot to work around this, but it hasn't
+    been packaged by your OS yet. If you have to obtain a certificate and
+    cannot wait, you have a couple of options. If you're serving files for that
+    domain out of a directory on that server, you can run the following
+    command:
     </p>
     <pre>$ sudo {{base_command}} --authenticator webroot --installer apache</pre>
     <p>
@@ -53,7 +57,7 @@ many platforms, and automates certificate installation.
     first drop-down menu above.
 
     If you're not serving files out of a directory on the server, you can
-    temporarily stop your server while you obtain the certificate, however,
+    temporarily stop your server while you obtain the certificate; however,
     you'll have to configure Apache to use the certificate yourself.
     The command to do this would something look like:
     </p>

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -1,35 +1,34 @@
 <p>
 Certbot has a fairly solid beta-quality Apache plugin, which is supported on
-many platforms, and automates certificate installation.
+many platforms, and automates both obtaining and installing certs:
 </p>
+<pre>$ sudo {{base_command}} --apache</pre>
 <p>
-Due to a security issue, Let's Encrypt has stopped offering the mechanism that
-the Apache plugin previously used to prove you control a domain. You can read
-more about this <a
-href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
-</p>
-<p>
-We are planning on releasing a new version of Certbot in the next few days that
-works around this but if you have to obtain a certificate and cannot wait, you
-have a couple of options. If you're serving files for that domain out of a
-directory on that server, you can run the following command:
-</p>
-<pre>$ sudo {{base_command}} --authenticator webroot --installer apache</pre>
-<p>
-If you're not serving files out of a directory on the server, you can
-temporarily stop your server while you obtain the certificate and restart it
-after Certbot has obtained the certificate. This would look like:
-</p>
-<pre>$ sudo {{base_command}} --authenticator standalone --installer apache --pre-hook "apachectl -k stop" --post-hook "apachectl -k start"</pre>
-<p>
-Running either of these commands will get a certificate for you and have
-Certbot edit your Apache configuration automatically to serve it. If you're
-feeling more conservative and would like to make the changes to your Apache
-configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
-instructions on how to use this subcommand, select "None of the above" in the
-first drop-down menu above.
-</p>
-<p>
+Running this command will get a certificate for you and have Certbot edit your Apache configuration
+automatically to serve it. If you're feeling more conservative and would like to make the changes to your
+Apache configuration by hand, you can use the <tt>certonly</tt>
+subcommand:
+<pre>$ sudo {{base_command}} --apache certonly</pre>
+
+{{#advanced}}
+    <aside class="note">
+        <h4>Note:</h4>
+        <p>the apache plugin with <tt>certonly</tt> does the following:<br>
+        <ol>
+          <li>make temporary config changes<br>
+          (adding a new vhost to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
+          <li>performs a graceful reload</li>
+          <li>reverts all changes</li>
+          <li>performs another graceful reload</li>
+        </ol>
+        This appears to be a reliable process, but if you don't want Certbot
+        to touch your Apache process or files in any way, you can use the
+        <a
+        href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+
+        </p></aside>
+{{/advanced}}
+
 To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
 </p>
 {{> renewal}}

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -1,33 +1,71 @@
 <p>
 Certbot has a fairly solid beta-quality Apache plugin, which is supported on
-many platforms, and automates both obtaining and installing certs:
+many platforms, and automates certificate installation.
 </p>
-<pre>$ sudo {{base_command}} --apache</pre>
-<p>
-Running this command will get a certificate for you and have Certbot edit your Apache configuration
-automatically to serve it. If you're feeling more conservative and would like to make the changes to your
-Apache configuration by hand, you can use the <tt>certonly</tt>
-subcommand:
-<pre>$ sudo {{base_command}} --apache certonly</pre>
+{{#installer_http01}}
+    <pre>$ sudo {{base_command}} --apache</pre>
+    <p>
+    Running this command will get a certificate for you and have Certbot edit your Apache configuration
+    automatically to serve it. If you're feeling more conservative and would like to make the changes to your
+    Apache configuration by hand, you can use the <tt>certonly</tt>
+    subcommand:
+    <pre>$ sudo {{base_command}} --apache certonly</pre>
 
-{{#advanced}}
-    <aside class="note">
-        <h4>Note:</h4>
-        <p>the apache plugin with <tt>certonly</tt> does the following:<br>
-        <ol>
-          <li>make temporary config changes<br>
-          (adding a new vhost to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
-          <li>performs a graceful reload</li>
-          <li>reverts all changes</li>
-          <li>performs another graceful reload</li>
-        </ol>
-        This appears to be a reliable process, but if you don't want Certbot
-        to touch your Apache process or files in any way, you can use the
-        <a
-        href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+    {{#advanced}}
+        <aside class="note">
+            <h4>Note:</h4>
+            <p>the apache plugin with <tt>certonly</tt> does the following:<br>
+            <ol>
+              <li>make temporary config changes<br>
+              (adding a new vhost to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
+              <li>performs a graceful reload</li>
+              <li>reverts all changes</li>
+              <li>performs another graceful reload</li>
+            </ol>
+            This appears to be a reliable process, but if you don't want Certbot
+            to touch your Apache process or files in any way, you can use the
+            <a
+            href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
 
-        </p></aside>
-{{/advanced}}
+            </p></aside>
+    {{/advanced}}
+{{/installer_http01}}
+{{^installer_http01}}
+    <p>
+    Due to a security issue, Let's Encrypt has stopped offering the mechanism that
+    the Apache plugin previously used to prove you control a domain. You can read
+    more about this <a
+    href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
+    </p>
+    <p>
+    We released a new version of Certbot to work around this, but it's not been
+    packaged by your OS yet. If you have to obtain a certificate and cannot
+    wait, you have a couple of options. If you're serving files for that domain
+    out of a directory on that server, you can run the following command:
+    </p>
+    <pre>$ sudo {{base_command}} --authenticator webroot --installer apache</pre>
+    <p>
+    This command will get a certificate for you and have Certbot edit your
+    Apache configuration to automatically serve it. If you're
+    feeling more conservative and would like to make the changes to your Apache
+    configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
+    instructions on how to use this subcommand, select "None of the above" in the
+    first drop-down menu above.
+
+    If you're not serving files out of a directory on the server, you can
+    temporarily stop your server while you obtain the certificate, however,
+    you'll have to configure Apache to use the certificate yourself.
+    The command to do this would look like:
+    </p>
+    <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "apachectl -k stop" --post-hook "apachectl -k start"</pre>
+    <p>
+    By using a command with hooks like this, if you automate renewal as
+    described below, Certbot will automatically stop and start Apache when you
+    need to renew your certificates. If you configure Apache to use the
+    symlinks in the "live" directory as instructed by Certbot, Apache will
+    automatically begin using any renewed certificates.
+    </p>
+{{/installer_http01}}
 
 To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
 </p>

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -55,15 +55,17 @@ many platforms, and certificate installation.
     If you're not serving files out of a directory on the server, you can
     temporarily stop your server while you obtain the certificate, however,
     you'll have to configure Nginx to use the certificate yourself.
-    The command to do this would look like:
+    The command to do this would look something like:
     </p>
     <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "nginx -s stop" --post-hook "nginx"</pre>
     <p>
-    By using a command with hooks like this, if you automate renewal as
-    described below, Certbot will automatically stop and start Nginx when you
-    need to renew your certificates. If you configure Nginx to use the
-    symlinks in the "live" directory as instructed by Certbot, Nginx will
-    automatically begin using any renewed certificates.
+    If you usually use a command like <tt>systemctl</tt> or
+    <tt>service</tt> to start and stop Nginx, you should use those commands
+    instead in the hooks above. By using a command with hooks like this, if
+    you automate renewal as described below, Certbot will automatically stop
+    and start Nginx when you need to renew your certificates. If you configure
+    Nginx to use the symlinks in the "live" directory as instructed by
+    Certbot, Nginx will automatically begin using any renewed certificates.
     </p>
 {{/installer_http01}}
 

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -2,34 +2,71 @@
 Certbot has an Nginx plugin, which is supported on
 many platforms, and certificate installation.
 </p>
-<p>
-Due to a security issue, Let's Encrypt has stopped offering the mechanism that
-the Nginx plugin previously used to prove you control a domain. You can read
-more about this <a
-href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
-</p>
-<p>
-We are planning on releasing a new version of Certbot in the next few days that
-works around this but if you have to obtain a certificate and cannot wait, you
-have a couple of options. If you're serving files for that domain out of a
-directory on that server, you can run the following command:
-</p>
-<pre>$ sudo {{base_command}} --authenticator webroot --installer nginx</pre>
-<p>
-If you're not serving files out of a directory on the server, you can
-temporarily stop your server while you obtain the certificate and restart it
-after Certbot has obtained the certificate. This would look like:
-</p>
-<pre>$ sudo {{base_command}} --authenticator standalone --installer nginx --pre-hook "nginx -s stop" --post-hook "nginx"</pre>
-<p>
-Running either of these commands will get a certificate for you and have
-Certbot edit your Nginx configuration automatically to serve it. If you're
-feeling more conservative and would like to make the changes to your Nginx
-configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
-instructions on how to use this subcommand, select "None of the above" in the
-first drop-down menu above.
-</p>
-<p>
+{{#installer_http01}}
+    <pre>$ sudo {{base_command}} --nginx</pre>
+    <p>
+    Running this command will get a certificate for you and have Certbot edit your Nginx configuration
+    automatically to serve it. If you're feeling more conservative and would like to make the changes to your
+    Nginx configuration by hand, you can use the <tt>certonly</tt>
+    subcommand:
+    <pre>$ sudo {{base_command}} --nginx certonly</pre>
+
+    {{#advanced}}
+        <aside class="note">
+            <h4>Note:</h4>
+            <p>the Nginx plugin with <tt>certonly</tt> does the following:<br>
+            <ol>
+              <li>make temporary config changes<br>
+              (adding a new server block to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>)</li>
+              <li>performs a graceful reload</li>
+              <li>reverts all changes</li>
+              <li>performs another graceful reload</li>
+            </ol>
+            This appears to be a reliable process, but if you don't want Certbot
+            to touch your Nginx process or files in any way, you can use the
+            <a
+            href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+
+            </p></aside>
+    {{/advanced}}
+{{/installer_http01}}
+{{^installer_http01}}
+    <p>
+    Due to a security issue, Let's Encrypt has stopped offering the mechanism that
+    the Nginx plugin previously used to prove you control a domain. You can read
+    more about this <a
+    href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
+    </p>
+    <p>
+    We released a new version of Certbot to work around this, but it's not been
+    packaged by your OS yet. If you have to obtain a certificate and cannot
+    wait, you have a couple of options. If you're serving files for that domain
+    out of a directory on that server, you can run the following command:
+    </p>
+    <pre>$ sudo {{base_command}} --authenticator webroot --installer nginx</pre>
+    <p>
+    This command will get a certificate for you and have Certbot edit your
+    Nginx configuration to automatically serve it. If you're
+    feeling more conservative and would like to make the changes to your Nginx
+    configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
+    instructions on how to use this subcommand, select "None of the above" in the
+    first drop-down menu above.
+
+    If you're not serving files out of a directory on the server, you can
+    temporarily stop your server while you obtain the certificate, however,
+    you'll have to configure Nginx to use the certificate yourself.
+    The command to do this would look like:
+    </p>
+    <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "nginx -s stop" --post-hook "nginx"</pre>
+    <p>
+    By using a command with hooks like this, if you automate renewal as
+    described below, Certbot will automatically stop and start Nginx when you
+    need to renew your certificates. If you configure Nginx to use the
+    symlinks in the "live" directory as instructed by Certbot, Nginx will
+    automatically begin using any renewed certificates.
+    </p>
+{{/installer_http01}}
+
 To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
 </p>
 {{> renewal}}

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -25,7 +25,8 @@ many platforms, and certificate installation.
             This appears to be a reliable process, but if you don't want Certbot
             to touch your Nginx process or files in any way, you can use the
             <a
-            href="https://certbot.eff.org/docs/using.html#webroot">webroot plugin</a>.
+            href="https://certbot.eff.org/docs/using.html#webroot">webroot
+            plugin</a> instead.
 
             </p></aside>
     {{/advanced}}
@@ -38,10 +39,11 @@ many platforms, and certificate installation.
     href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
     </p>
     <p>
-    We released a new version of Certbot to work around this, but it's not been
-    packaged by your OS yet. If you have to obtain a certificate and cannot
-    wait, you have a couple of options. If you're serving files for that domain
-    out of a directory on that server, you can run the following command:
+    We released a new version of Certbot to work around this, but it hasn't
+    been packaged by your OS yet. If you have to obtain a certificate and
+    cannot wait, you have a couple of options. If you're serving files for that
+    domain out of a directory on that server, you can run the following
+    command:
     </p>
     <pre>$ sudo {{base_command}} --authenticator webroot --installer nginx</pre>
     <p>
@@ -53,7 +55,7 @@ many platforms, and certificate installation.
     first drop-down menu above.
 
     If you're not serving files out of a directory on the server, you can
-    temporarily stop your server while you obtain the certificate, however,
+    temporarily stop your server while you obtain the certificate; however,
     you'll have to configure Nginx to use the certificate yourself.
     The command to do this would look something like:
     </p>


### PR DESCRIPTION
The two places where the Apache and Nginx plugins are packaged but not yet updated (when following our installation instructions) are Debian backports and Gentoo. (Gentoo actually has it packaged but it's still in testing so it won't be installed by default.)

I also changed our instructions around standalone to reflect certbot/certbot#2419, certbot/certbot#5486, and certbot/certbot#5555. I put `apachectl`/`nginx` directly in the hooks because that should cause the hooks to work on any system, but I suggested using `systemctl` or `service` instead if you normally use those commands to control Apache/Nginx.