### PR TITLE
Link to /docs/ instead of /docs

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -71,6 +71,6 @@ many platforms, and certificate installation.
     </p>
 {{/installer_http01}}
 
-To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
+To learn more about how to use Certbot <a href="/docs/">read our documentation</a>.
 </p>
 {{> renewal}}


### PR DESCRIPTION
https://certbot.eff.org/docs has approximately the same text, but is missing the CSS and every link 404s.
https://certbot.eff.org/docs/ loads the CSS and links work.