### PR TITLE
Add trailing slash in documentation link

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -73,6 +73,6 @@ many platforms, and automates certificate installation.
     </p>
 {{/installer_http01}}
 
-To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
+To learn more about how to use Certbot <a href="/docs/">read our documentation</a>.
 </p>
 {{> renewal}}

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -71,6 +71,6 @@ many platforms, and certificate installation.
     </p>
 {{/installer_http01}}
 
-To learn more about how to use Certbot <a href="/docs">read our documentation</a>.
+To learn more about how to use Certbot <a href="/docs/">read our documentation</a>.
 </p>
 {{> renewal}}


### PR DESCRIPTION
Probably fixes https://github.com/certbot/certbot/issues/5595