### PR TITLE
Revert TLS-SNI warning

### DIFF
--- a/_includes/sni-warning.html
+++ b/_includes/sni-warning.html
@@ -1,8 +1,0 @@
-<div>
-  <aside class="warning" id="sni-warning">
-    <p>
-        If you are having trouble obtaining certificates using the Apache or
-        Nginx plugins, fill out the dropdown menus below to get updated
-        installation and usage instructions for your system.
-  </aside>
-</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,6 @@
 
     {% include topnav.html %}
     {% include shelf.html %}
-    {% include sni-warning.html %}
     {% include subhero.html %}
     
     <div class="page-content">

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -20,7 +20,6 @@ Like looking at code? Help us! https://github.com/certbot/certbot
 
     {% include topnav.html %}
     {% include shelf.html %}
-    {% include sni-warning.html %}
     {% include hero.html %}
 
     <div class="page-content">

--- a/_sass/_sni-warning.scss
+++ b/_sass/_sni-warning.scss
@@ -1,4 +1,0 @@
-#sni-warning {
-  min-height: 50px;
-  text-align: center;
-}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -81,8 +81,7 @@ $on-laptop:        800px;
         "instruction-widget",
         "faq",
         "social",
-        "privacy",
-        "sni-warning"
+        "privacy"
 ;
 
 .page-content  {


### PR DESCRIPTION
This reverts commit 094092e6f29d4e83b52ed96d621a06a709fe0b5e.

It's been ~2 months since this incident so I think we can safely remove the warning.