### PR TITLE
Bump Fedora text and version

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -101,10 +101,10 @@
             "version": "0"
         },
         {
-            "name": "Fedora 24+",
+            "name": "Fedora 26+",
             "id": "fedora24",
             "distro": "fedora",
-            "version": "24"
+            "version": "26"
         },
         {
             "name": "CentOS 6",


### PR DESCRIPTION
Fedora 24 and 25 are no longer supported by Fedora. The reason the `id` is left unchanged is explained in #323.