### PR TITLE
Add new OS dependencies to build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
 addons:
   apt:
     packages:
+      - imagemagick
+      - latexmk
       - texlive
       - texlive-latex-extra
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ENV LC_ALL C.UTF-8
 
 # need rsync for deploy script and texlive for building docs
 RUN apt-get install -y --no-install-recommends \
+    imagemagick \
+    latexmk \
     rsync \
     texlive \
     texlive-latex-extra


### PR DESCRIPTION
imagemagick is needed for sphinx.ext.imgconverter and latexmk is needed for
Sphinx 1.6+.

Prep for https://github.com/certbot/certbot/pull/6070.