### PR TITLE
Add generic fedora OS and hide fedora24

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -101,6 +101,12 @@
             "version": "26"
         },
         {
+            "name": "Fedora 26+",
+            "id": "fedora",
+            "distro": "fedora",
+            "version": "26"
+        },
+        {
             "name": "CentOS 6",
             "id": "centos6",
             "distro": "centos",

--- a/_includes/form.html
+++ b/_includes/form.html
@@ -14,7 +14,9 @@
     <optgroup>
       <option value="" disabled selected>System</option>
       {% for os in site.data.inputs.operating_systems %}
-        <option value="{{ os.id }}" data-distro="{{ os.distro }}" data-version="{{ os.version }}">{{ os.name }}</option>
+        {% if os.id != "fedora24" %}
+          <option value="{{ os.id }}" data-distro="{{ os.distro }}" data-version="{{ os.version }}">{{ os.name }}</option>
+        {% endif %}
       {% endfor %}
     </optgroup>
   </select>


### PR DESCRIPTION
Part of #323

This creates identical pages at `/lets-encrypt/fedora-apache` and `/lets-encrypt/fedora24-apache`, but excludes `fedora24` from the dropdown options.

I think an nginx redirect would still ultimately be cleaner, but this will help with the switchover.