### PR TITLE
Remove fedora24

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -96,12 +96,6 @@
         },
         {
             "name": "Fedora 26+",
-            "id": "fedora24",
-            "distro": "fedora",
-            "version": "26"
-        },
-        {
-            "name": "Fedora 26+",
             "id": "fedora",
             "distro": "fedora",
             "version": "26"

--- a/_includes/form.html
+++ b/_includes/form.html
@@ -14,9 +14,7 @@
     <optgroup>
       <option value="" disabled selected>System</option>
       {% for os in site.data.inputs.operating_systems %}
-        {% if os.id != "fedora24" %}
-          <option value="{{ os.id }}" data-distro="{{ os.distro }}" data-version="{{ os.version }}">{{ os.name }}</option>
-        {% endif %}
+        <option value="{{ os.id }}" data-distro="{{ os.distro }}" data-version="{{ os.version }}">{{ os.name }}</option>
       {% endfor %}
     </optgroup>
   </select>


### PR DESCRIPTION
Fixes #323.

The redirect from fedora24 to fedora has been set up so we can remove our fedora24 code.