### PR TITLE
Clarify how to install from the PPA.

### DIFF
--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,6 +1,6 @@
 {{> header}}
 <p>
-On Ubuntu systems, the Certbot team maintains a <a href="https://help.ubuntu.com/community/PPA">PPA</a>. Once you add it to your list of repositories all you'll need to do is apt-get the following packages.
+On Ubuntu systems, the Certbot team maintains a <a href="https://help.ubuntu.com/community/PPA">PPA</a>. You can add it to your list of repositories and install Certbot by running the following commands.
 </p>
 
 <pre>


### PR DESCRIPTION
It says “Once you add it to your list of repositories all you’ll need to do is apt-get the following packages.” Then it gives a list of commands. So someone unfamiliar with apt-get might conclude that they needed to somehow find and add the PPA _before_ going through the list of commands. I think that may be what happened [here](https://community.letsencrypt.org/t/why-dont-you-give-the-ppa-for-ubuntu/74072).