### PR TITLE
Fix unclosed paragraph

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/certonly.html
+++ b/_scripts/instruction-widget/templates/getting-started/certonly.html
@@ -11,6 +11,7 @@ certificate.
 This will allow you interactively select the plugin and options used to obtain
 your certificate. If you already have a webserver running, we recommend
 choosing the <a href="/docs/using.html#webroot">"webroot" plugin</a>.
+</p>
 <p>
 Alternatively, you can specify more information on the command line.
 </p>


### PR DESCRIPTION
Liquid (the templating engine we're using with Jekyll) was html-escaping some divs to fix invalid markup resulting from this. I tried to find a setting that would make Liquid error the build rather than attempting fixing it (badly), but I couldn't find anything. 