### PR TITLE
Ensure Debian/Devuan installations have HTTP-01 support

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -149,16 +149,22 @@
             "version": "10"
         },
         {
+            "name": "Devuan ASCII 2.0",
+            "id": "devuanascii",
+            "distro": "devuan",
+            "version": "2"
+        },
+        {
             "name": "Devuan Jessie 1.0",
             "id": "devuanjessie",
             "distro": "devuan",
             "version": "1"
         },
         {
-            "name": "Devuan (other)",
+            "name": "Devuan testing/unstable",
             "id": "devuanother",
             "distro": "devuan",
-            "version": "0"
+            "version": "3"
         },
         {
           "name": "openSUSE Tumbleweed",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -30,7 +30,7 @@ module.exports = function(context) {
         context.distro == "sharedhost") {
         return '';
     }
-    else if (context.distro == "debian" && context.version > 7) {
+    else if (context.distro == "debian" && context.version > 8) {
       debian_install();
     }
     else if (context.distro == "ubuntu" && context.version >= 14.04){
@@ -103,41 +103,23 @@ module.exports = function(context) {
 
   debian_install = function() {
     template = "debian";
-    context.devuan = context.distro == "devuan"
-    context.jessie = context.version == 8
-    context.stretch = context.version == 9
 
-    // Now default for Debian, undone only in Jessie case below
     context.dns_plugins = true;
 
-    // Debian Jessie
     context.base_command = "certbot";
     context.cron_included = true;
     context.package = "certbot";
 
     if (context.webserver == "apache") {
       context.package = "python-certbot-apache";
-    }
-
-    // Jessie backports.
-    if ((context.devuan && context.version == 1) || context.jessie) {
-      context.dns_plugins = false;
-      context.backports_flag = "-t jessie-backports";
-      context.installer_http01 = false;
-      if (context.webserver == "nginx") {
-        context.certonly = true;
-      }
-    }
-    if (context.stretch) {
-      context.backports_flag = "-t stretch-backports";
-      if (context.webserver == "nginx") {
-        context.package = "python-certbot-nginx";
-      }
-    }
-    if (context.version == 10 && context.webserver == "nginx") {
+    } else if (context.webserver == "nginx") {
       context.package = "python-certbot-nginx";
     }
 
+    // Debian Stretch
+    if (context.version == 9) {
+      context.backports_flag = "-t stretch-backports";
+    }
   }
 
   ubuntu_install = function() {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -104,8 +104,6 @@ module.exports = function(context) {
   debian_install = function() {
     template = "debian";
     context.devuan = context.distro == "devuan"
-    context.jessie = context.version == 8
-    context.stretch = context.version == 9
 
     context.dns_plugins = true;
 
@@ -119,7 +117,8 @@ module.exports = function(context) {
       context.package = "python-certbot-nginx";
     }
 
-    if (context.stretch) {
+    if (context.version == 9) {
+      // Debian Stretch
       context.backports_flag = "-t stretch-backports";
     } else if (context.devuan && context.version == 2) {
       // Devuan ASCII

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -121,7 +121,7 @@ module.exports = function(context) {
 
     if (context.stretch) {
       context.backports_flag = "-t stretch-backports";
-    } else if (context.distro == "devuan" && context.version == 2) {
+    } else if (context.devuan && context.version == 2) {
       // Devuan ASCII
       context.backports_flag = "-t ascii-backports";
     }

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -57,7 +57,7 @@ module.exports = function(context) {
     }
     else if (context.distro == "macos") {
       macos_install();
-    } else if (context.distro == "devuan") {
+    } else if (context.distro == "devuan" && context.version > 1) {
       debian_install();
     } else if (context.distro == "opensuse") {
       opensuse_install();
@@ -116,9 +116,12 @@ module.exports = function(context) {
       context.package = "python-certbot-nginx";
     }
 
-    // Debian Stretch
     if (context.version == 9) {
+      // Debian Stretch
       context.backports_flag = "-t stretch-backports";
+    } else if (context.distro == "devuan" && context.version == 2) {
+      // Devuan ASCII
+      context.backports_flag = "-t ascii-backports";
     }
   }
 

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -103,6 +103,9 @@ module.exports = function(context) {
 
   debian_install = function() {
     template = "debian";
+    context.devuan = context.distro == "devuan"
+    context.jessie = context.version == 8
+    context.stretch = context.version == 9
 
     context.dns_plugins = true;
 
@@ -116,8 +119,7 @@ module.exports = function(context) {
       context.package = "python-certbot-nginx";
     }
 
-    if (context.version == 9) {
-      // Debian Stretch
+    if (context.stretch) {
       context.backports_flag = "-t stretch-backports";
     } else if (context.distro == "devuan" && context.version == 2) {
       // Devuan ASCII

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -6,12 +6,13 @@
 {{#backports_flag}}
 <p>
 {{#devuan}}
-First you'll have to enable the Jessie backports repo in your APT sources as
+First you'll have to enable the ASCII backports repo in your APT sources as
 shown <a
 href='https://devuan.org/os/etc/apt/sources.list#add-backports-default-no'>here</a>.
 {{/devuan}}
 {{^devuan}}
-First you'll have to follow the instructions <a href='http://backports.debian.org/Instructions/'>here</a> to enable the {{#jessie}}Jessie{{/jessie}}{{#stretch}}Stretch{{/stretch}}
+First you'll have to follow the instructions <a
+href='http://backports.debian.org/Instructions/'>here</a> to enable the Stretch
 backports repo, if you have not already done so.
 {{/devuan}}
 Then run:


### PR DESCRIPTION
The changes made in this PR were:

* Tell Debian & Devuan Jessie users to use `certbot-auto` rather than the old version of Certbot without HTTP-01 support that's available in their backports repo.
* Add instructions for Devuan ASCII (which for our purposes is basically the same as Debian Stretch)