### PR TITLE
Remove instructions for Certbot with HTTP-01 support

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -22,7 +22,6 @@ module.exports = function(context) {
   html = function() {
 
     context.cron_included = false;
-    context.installer_http01 = true;
     context.dns_plugins = false;
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
@@ -147,7 +146,6 @@ module.exports = function(context) {
     context.package = "certbot";
     context.base_command = "certbot";
     context.base_package = "app-crypt/certbot";
-    context.installer_http01 = false;
     if (context.webserver == "apache") {
       context.package = "certbot-apache";
     } else if (context.webserver == "nginx") {

--- a/_scripts/instruction-widget/templates/getting-started/apache.html
+++ b/_scripts/instruction-widget/templates/getting-started/apache.html
@@ -2,76 +2,35 @@
 Certbot has a fairly solid beta-quality Apache plugin, which is supported on
 many platforms, and automates certificate installation.
 </p>
-{{#installer_http01}}
-    <pre>$ sudo {{base_command}} --apache</pre>
-    <p>
-    Running this command will get a certificate for you and have Certbot edit your Apache configuration
-    automatically to serve it. If you're feeling more conservative and would like to make the changes to your
-    Apache configuration by hand, you can use the <tt>certonly</tt>
-    subcommand:
-    <pre>$ sudo {{base_command}} --apache certonly</pre>
+<pre>$ sudo {{base_command}} --apache</pre>
+<p>
+Running this command will get a certificate for you and have Certbot edit your Apache configuration
+automatically to serve it. If you're feeling more conservative and would like to make the changes to your
+Apache configuration by hand, you can use the <tt>certonly</tt>
+subcommand:
+<pre>$ sudo {{base_command}} --apache certonly</pre>
 
-    {{#advanced}}
-        <aside class="note">
-            <h4>Note:</h4>
-            <p>the apache plugin with <tt>certonly</tt> does the following:<br>
-            <ol>
-              <li>make temporary config changes<br> (adding a new virtual host
-              to pass an <a
-              href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME
-              Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
-              <li>performs a graceful reload</li>
-              <li>reverts all changes</li>
-              <li>performs another graceful reload</li>
-            </ol>
-            This appears to be a reliable process, but if you don't want Certbot
-            to touch your Apache process or files in any way, you can use the
-            <a
-            href="https://certbot.eff.org/docs/using.html#webroot">webroot
-            plugin</a> instead.
+{{#advanced}}
+    <aside class="note">
+        <h4>Note:</h4>
+        <p>the apache plugin with <tt>certonly</tt> does the following:<br>
+        <ol>
+          <li>make temporary config changes<br> (adding a new virtual host
+          to pass an <a
+          href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME
+          Challenge</a>, and enabling <tt>mod_ssl</tt> if necessary)</li>
+          <li>performs a graceful reload</li>
+          <li>reverts all changes</li>
+          <li>performs another graceful reload</li>
+        </ol>
+        This appears to be a reliable process, but if you don't want Certbot
+        to touch your Apache process or files in any way, you can use the
+        <a
+        href="https://certbot.eff.org/docs/using.html#webroot">webroot
+        plugin</a> instead.
 
-            </p></aside>
-    {{/advanced}}
-{{/installer_http01}}
-{{^installer_http01}}
-    <p>
-    Due to a security issue, Let's Encrypt has stopped offering the mechanism that
-    the Apache plugin previously used to prove you control a domain. You can read
-    more about this <a
-    href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
-    </p>
-    <p>
-    We released a new version of Certbot to work around this, but it hasn't
-    been packaged by your OS yet. If you have to obtain a certificate and
-    cannot wait, you have a couple of options. If you're serving files for that
-    domain out of a directory on that server, you can run the following
-    command:
-    </p>
-    <pre>$ sudo {{base_command}} --authenticator webroot --installer apache</pre>
-    <p>
-    This command will get a certificate for you and have Certbot edit your
-    Apache configuration to automatically serve it. If you're
-    feeling more conservative and would like to make the changes to your Apache
-    configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
-    instructions on how to use this subcommand, select "None of the above" in the
-    first drop-down menu above.
-
-    If you're not serving files out of a directory on the server, you can
-    temporarily stop your server while you obtain the certificate; however,
-    you'll have to configure Apache to use the certificate yourself.
-    The command to do this would something look like:
-    </p>
-    <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "apachectl -k stop" --post-hook "apachectl -k start"</pre>
-    <p>
-    If you usually use a command like <tt>systemctl</tt> or
-    <tt>service</tt> to start and stop Apache, you should use those commands
-    instead in the hooks above. By using a command with hooks like this, if
-    you automate renewal as described below, Certbot will automatically stop
-    and start Apache when you need to renew your certificates. If you configure
-    Apache to use the symlinks in the "live" directory as instructed by
-    Certbot, Apache will automatically begin using any renewed certificates.
-    </p>
-{{/installer_http01}}
+        </p></aside>
+{{/advanced}}
 {{#dns_plugins}}
 <p>
 <strong>If you want to obtain a wildcard certificate using Let's Encrypt's new ACMEv2

--- a/_scripts/instruction-widget/templates/getting-started/nginx.html
+++ b/_scripts/instruction-widget/templates/getting-started/nginx.html
@@ -2,74 +2,33 @@
 Certbot has an Nginx plugin, which is supported on
 many platforms, and certificate installation.
 </p>
-{{#installer_http01}}
-    <pre>$ sudo {{base_command}} --nginx</pre>
-    <p>
-    Running this command will get a certificate for you and have Certbot edit your Nginx configuration
-    automatically to serve it. If you're feeling more conservative and would like to make the changes to your
-    Nginx configuration by hand, you can use the <tt>certonly</tt>
-    subcommand:
-    <pre>$ sudo {{base_command}} --nginx certonly</pre>
+<pre>$ sudo {{base_command}} --nginx</pre>
+<p>
+Running this command will get a certificate for you and have Certbot edit your Nginx configuration
+automatically to serve it. If you're feeling more conservative and would like to make the changes to your
+Nginx configuration by hand, you can use the <tt>certonly</tt>
+subcommand:
+<pre>$ sudo {{base_command}} --nginx certonly</pre>
 
-    {{#advanced}}
-        <aside class="note">
-            <h4>Note:</h4>
-            <p>the Nginx plugin with <tt>certonly</tt> does the following:<br>
-            <ol>
-              <li>make temporary config changes<br>
-              (adding a new server block to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>)</li>
-              <li>performs a graceful reload</li>
-              <li>reverts all changes</li>
-              <li>performs another graceful reload</li>
-            </ol>
-            This appears to be a reliable process, but if you don't want Certbot
-            to touch your Nginx process or files in any way, you can use the
-            <a
-            href="https://certbot.eff.org/docs/using.html#webroot">webroot
-            plugin</a> instead.
+{{#advanced}}
+    <aside class="note">
+        <h4>Note:</h4>
+        <p>the Nginx plugin with <tt>certonly</tt> does the following:<br>
+        <ol>
+          <li>make temporary config changes<br>
+          (adding a new server block to pass an <a href="https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.3">ACME Challenge</a>)</li>
+          <li>performs a graceful reload</li>
+          <li>reverts all changes</li>
+          <li>performs another graceful reload</li>
+        </ol>
+        This appears to be a reliable process, but if you don't want Certbot
+        to touch your Nginx process or files in any way, you can use the
+        <a
+        href="https://certbot.eff.org/docs/using.html#webroot">webroot
+        plugin</a> instead.
 
-            </p></aside>
-    {{/advanced}}
-{{/installer_http01}}
-{{^installer_http01}}
-    <p>
-    Due to a security issue, Let's Encrypt has stopped offering the mechanism that
-    the Nginx plugin previously used to prove you control a domain. You can read
-    more about this <a
-    href="https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188">here</a>.
-    </p>
-    <p>
-    We released a new version of Certbot to work around this, but it hasn't
-    been packaged by your OS yet. If you have to obtain a certificate and
-    cannot wait, you have a couple of options. If you're serving files for that
-    domain out of a directory on that server, you can run the following
-    command:
-    </p>
-    <pre>$ sudo {{base_command}} --authenticator webroot --installer nginx</pre>
-    <p>
-    This command will get a certificate for you and have Certbot edit your
-    Nginx configuration to automatically serve it. If you're
-    feeling more conservative and would like to make the changes to your Nginx
-    configuration by hand, you can use the <tt>certonly</tt> subcommand. To see
-    instructions on how to use this subcommand, select "None of the above" in the
-    first drop-down menu above.
-
-    If you're not serving files out of a directory on the server, you can
-    temporarily stop your server while you obtain the certificate; however,
-    you'll have to configure Nginx to use the certificate yourself.
-    The command to do this would look something like:
-    </p>
-    <pre>$ sudo {{base_command}} certonly --authenticator standalone --pre-hook "nginx -s stop" --post-hook "nginx"</pre>
-    <p>
-    If you usually use a command like <tt>systemctl</tt> or
-    <tt>service</tt> to start and stop Nginx, you should use those commands
-    instead in the hooks above. By using a command with hooks like this, if
-    you automate renewal as described below, Certbot will automatically stop
-    and start Nginx when you need to renew your certificates. If you configure
-    Nginx to use the symlinks in the "live" directory as instructed by
-    Certbot, Nginx will automatically begin using any renewed certificates.
-    </p>
-{{/installer_http01}}
+        </p></aside>
+{{/advanced}}
 {{#dns_plugins}}
 <p>
 <strong>If you want to obtain a wildcard certificate using Let's Encrypt's new ACMEv2


### PR DESCRIPTION
We are no longer recommending anyone installs a version of Certbot with out HTTP-01 support. This reverts commit 9b59ea6960704677bc89ce21cd8ee96a700d2506, reversing
changes made to ac64cce4fff4ff94e4dc5c5205ad3bff54903939.

The diffs for the Apache and Nginx templates are pretty awful. The only changes I made there is I deleted the tags for `installer_http01`, relevant indentation, and the instructions for Certbot when the installer doesn't support HTTP-01.

This also stops us from showing these instructions for Gentoo. Support for HTTP-01 challenge was [added in 0.21.0](https://github.com/certbot/certbot/blob/36ebce4a5fa30a0e73bd8656aea54ded2e9d982e/CHANGELOG.md#added-7) and newer version of both the [Apache](https://packages.gentoo.org/packages/app-crypt/certbot-apache) and [Nginx](https://packages.gentoo.org/packages/app-crypt/certbot-nginx) plugin are packaged in Gentoo.