### PR TITLE
Exclude package-lock.json from build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ defaults:
 exclude:
 - README.md
 - package.json
+- package-lock.json
 - node_modules
 - gulpfile.js
 - vendor


### PR DESCRIPTION
We don't need to serve this :)