### PR TITLE
Ensure the universe repository is enabled

### DIFF
--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -6,6 +6,7 @@ On Ubuntu systems, the Certbot team maintains a <a href="https://help.ubuntu.com
 <pre>
 $ sudo apt-get update
 $ sudo apt-get install software-properties-common
+$ sudo add-apt-repository universe
 $ sudo add-apt-repository ppa:certbot/certbot
 $ sudo apt-get update
 $ sudo apt-get install {{package}} {{backports_flag}}


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/6362.

I tested this on Ubuntu 14.04, 18.04, and 18.10 and running `sudo add-apt-repository universe` when the universe repository is already enabled simply exits with a zero status and prints:
```
'universe' distribution component is already enabled for all sources.
```

@schoen, are you able to review this?