### PR TITLE
Update DNS plugin install guide to specify package prefixes per OS

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -23,6 +23,7 @@ module.exports = function(context) {
 
     context.cron_included = false;
     context.dns_plugins = false;
+    context.dns_package_prefix = "";
     context.jessie = false;  // Special jessie instructions for certbot-auto
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
@@ -101,6 +102,7 @@ module.exports = function(context) {
         context.package = "python2-certbot-nginx";
       }
       context.dns_plugins = true;
+      context.dns_package_prefix = "python2-certbot-dns"
     }
   }
 
@@ -109,6 +111,7 @@ module.exports = function(context) {
     context.devuan = context.distro == "devuan"
 
     context.dns_plugins = true;
+    context.dns_package_prefix = "python3-certbot-dns"
 
     context.base_command = "certbot";
     context.cron_included = true;
@@ -142,6 +145,7 @@ module.exports = function(context) {
     context.base_command = "certbot";
     context.cron_included = true;
     context.dns_plugins = true;
+    context.dns_package_prefix = "python3-certbot-dns"
   }
 
   gentoo_install = function() {
@@ -170,6 +174,7 @@ module.exports = function(context) {
     context.base_command = "certbot";
     context.base_package = "certbot";
     context.dns_plugins = true;
+    context.dns_package_prefix = "certbot-dns";
   }
 
   fedora_install = function() {
@@ -183,6 +188,7 @@ module.exports = function(context) {
       context.package = "certbot-nginx";
     }
     context.dns_plugins = true;
+    context.dns_package_prefix = "certbot-dns";
   }
   // @todo: convert to template style
   bsd_install = function() {
@@ -191,6 +197,7 @@ module.exports = function(context) {
     context.base_command = "certbot";
     if (context.distro == "freebsd"){
       context.dns_plugins = true;
+      context.dns_package_prefix = "py27-certbot-dns";
       context.portcommand = "py-certbot";
       context.package = "pkg install py27-certbot";
     }
@@ -228,6 +235,7 @@ module.exports = function(context) {
       context.package = "python-certbot-nginx";
     }
     context.dns_plugins = true;
+    context.dns_package_prefix = "python-certbot-dns";
   }
 
   auto_install = function() {

--- a/_scripts/instruction-widget/templates/install/dnsplugins.html
+++ b/_scripts/instruction-widget/templates/install/dnsplugins.html
@@ -1,21 +1,23 @@
+<h4>Installing DNS plugins</h4>
 {{#dns_plugins}}
 <p>
-<strong>Certbot's DNS plugins are also available for your system which can be used to
-automate obtaining a wildcard certificate from Let's Encrypt's ACMEv2 server.</strong>
-To use one of these plugins, you must have configured DNS for the domain you
-want to obtain a certificate for with a DNS provider that Certbot has a plugin
-for. A list of these plugins and more information about using them can be found
-<a href="/docs/using.html#dns-plugins">here</a>. To install one of these
-plugins, run the installation command above but replace {{package}} with the
-name of the DNS plugin you want to install.
+Certbot's DNS plugins <strong>are available</strong> for your system. These
+plugins can be used to automate obtaining a wildcard certificate from Let's
+Encrypt's ACMEv2 server.  To use one of these plugins, you must have configured
+DNS for the domain you want to obtain a certificate for with a DNS provider
+that Certbot has a plugin for. A list of these plugins and more information
+about using them can be found <a href="/docs/using.html#dns-plugins">here</a>.
+To install one of these plugins, run the installation command above but replace
+<tt>{{package}}</tt> with <tt>{{dns_package_prefix}}-PLUGIN</tt>, where <tt>PLUGIN</tt>
+is the name of the plugin you want to install.
 </p>
 {{/dns_plugins}}
 {{^dns_plugins}}
 <p>
-<strong>Certbot's DNS plugins which can be used to automate obtaining a wildcard
-certificate from Let's Encrypt's ACMEv2 server are not available for your OS
-yet.</strong> This should change soon but if you don't want to wait, you can use these
-plugins now by
+Certbot's DNS plugins <strong>are not available</strong> for your OS yet. These
+plugins can be used to automate obtaining a wildcard certificate from Let's
+Encrypt's ACMEv2 server. This should change soon but if you don't want to wait,
+you can use these plugins now by
 <a href="/docs/install.html#running-with-docker">running Certbot in Docker</a>
 instead of using the instructions on this page.
 </p>


### PR DESCRIPTION
fixes #362 
 * Specifies `dns_package_prefix` for OSes where DNS plugin is packaged.
 * Rewords DNS plugin install text to make it more clear whether a particular OS has it packaged, and to surface the DNS package name.

reviewer should double-check that these package names are correct