### PR TITLE
Change build status links to travis-ci.com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Website for [EFF's Certbot](https://certbot.eff.org/) project. Uses Jekyll for static site generation.
 
-[![Build Status](https://travis-ci.org/certbot/website.svg?branch=master)](https://travis-ci.org/certbot/website)
+[![Build Status](https://travis-ci.com/certbot/website.svg?branch=master)](https://travis-ci.com/certbot/website)
 
 ## Development
 


### PR DESCRIPTION
As part of migrating away from the now deprecated support for GitHub services, our Travis config has moved from travis-ci.org to travis-ci.com. This PR updates the links to our build status to use travis-ci.com.