### PR TITLE
 Add certbot to debian and ubuntu packages lists so it gets automatically upgraded

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -137,9 +137,9 @@ module.exports = function(context) {
 
     context.package = "certbot"
     if (context.webserver == "apache") {
-      context.package = "python-certbot-apache";
+      context.package += " " + "python-certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.package = "python-certbot-nginx";
+      context.package += " " + "python-certbot-nginx";
     }
     // Debian Jessie, Ubuntu 16.10, or newer
     context.base_command = "certbot";

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -118,9 +118,9 @@ module.exports = function(context) {
     context.package = "certbot";
 
     if (context.webserver == "apache") {
-      context.package = "python-certbot-apache";
+      context.package += " " + "python-certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.package = "python-certbot-nginx";
+      context.package += " " + "python-certbot-nginx";
     }
 
     if (context.version == 9) {


### PR DESCRIPTION
Fixes #392.

Adding `certbot` rather than `python-certbot` because `pyython-certbot` has an optional, but enabled by default dependency on `certbot`.