### PR TITLE
Remove Ubuntu 17.10 instructions.

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -53,12 +53,6 @@
             "version": "0"
         },
         {
-            "name": "Ubuntu 17.10 (artful)",
-            "id": "ubuntuartful",
-            "distro": "ubuntu",
-            "version": "17.10"
-        },
-        {
             "name": "Ubuntu 18.04 LTS (bionic)",
             "id": "ubuntubionic",
             "distro": "ubuntu",


### PR DESCRIPTION
The release has reached its end of life.