### PR TITLE
TLS-SNI-01 deprecation edit

### DIFF
--- a/_faq_entries/15-port-80.md
+++ b/_faq_entries/15-port-80.md
@@ -3,6 +3,6 @@ title:  "Can I issue a certificate if my webserver doesn't listen on port 80?"
 weight: 15
 ---
 
-Yes, using the TLS-ALPN-01 challenge. However, Certbot does not include support for this method yet. If you're using any Certbot with any method other than DNS authentication, your web server must listen on port 80, or at least be capable of doing so temporarily during certificate validation.
+Yes, using the DNS-01 or TLS-ALPN-01 challenge. However, Certbot does not include support for TLS-ALPN-01 yet. If you're using any Certbot with any method other than DNS authentication, your web server must listen on port 80, or at least be capable of doing so temporarily during certificate validation.
 
 If you have an ISP or firewall that blocks port 80 and you can't get it unblocked, you'll need to use DNS authentication or a different Let's Encrypt client.

--- a/_faq_entries/15-port-80.md
+++ b/_faq_entries/15-port-80.md
@@ -3,4 +3,6 @@ title:  "Can I issue a certificate if my webserver doesn't listen on port 80?"
 weight: 15
 ---
 
-Yes, using the TLS-SNI-01 challenge. At the moment, Certbot only implements this challenge for Apache. If you're using the [webroot mode](https://letsencrypt.readthedocs.org/en/latest/using.html#webroot), your web server must listen on port 80.
+Yes, using the TLS-ALPN-01 challenge. However, Certbot does not include support for this method yet. If you're using any Certbot with any method other than DNS authentication, your web server must listen on port 80, or at least be capable of doing so temporarily during certificate validation.
+
+If you have an ISP or firewall that blocks port 80 and you can't get it unblocked, you'll need to use DNS authentication or a different Let's Encrypt client.


### PR DESCRIPTION
Let users know about TLS-SNI-01 → TLS-ALPN-01 when they consult the Certbot website FAQ.

Fixes https://github.com/certbot/certbot/issues/6924.