### PR TITLE
Move freebsd from py27 to py36

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -197,9 +197,9 @@ module.exports = function(context) {
     context.base_command = "certbot";
     if (context.distro == "freebsd"){
       context.dns_plugins = true;
-      context.dns_package_prefix = "py27-certbot-dns";
+      context.dns_package_prefix = "py36-certbot-dns";
       context.portcommand = "py-certbot";
-      context.package = "pkg install py27-certbot";
+      context.package = "pkg install py36-certbot";
     }
     if (context.distro == "opbsd"){
       if (context.version >= 6) {


### PR DESCRIPTION
Freebsd has packages for both python3.6 and py36-certbot(-dns).

Would anyone be opposed to moving the instructions to python 3.6 instead of 2.7?