### PR TITLE
Small fixes post redesign launch

### DIFF
--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -150,6 +150,10 @@ ul.image-bullets {
     @include bullet-image;
     background-image: url('../images/BlackCircle-Lightbulb.svg');
   }
+  li.key-bullet {
+    @include bullet-image;
+    background-image: url('../images/BlackCircle-Key.svg');
+  }
 }
 a.anchor {
   text-decoration: underline;

--- a/_scripts/instruction-widget/templates/instructions.html
+++ b/_scripts/instruction-widget/templates/instructions.html
@@ -39,7 +39,7 @@
       <a class="link-button-wide" href="/docs/">See how to work with Certbot<img alt="Red arrow pointing right" src="/images/chevron-right.png" class="mobile-only link-arrow"/></a>
     </div>
     <div class="col">
-      <img alt="Key" src="/images/BlackCircle-Key.svg">
+      <img alt="Bag decorated with a heart" src="/images/BlackCircle-Donate.svg">
       <div class="text-wrapper">
         <span class="mobile-hidden">
           Like Certbot? This free, open source project is part of EFF's 

--- a/about/index.md
+++ b/about/index.md
@@ -33,7 +33,7 @@ Certbot might be right for you if you:
     have {% include tooltip.html term-name="website-thats-already-online" text="an HTTP website that’s already online" %}, with {% include tooltip.html term-name="port-80" text="port 80 open" %},
   </li>
   <li>
-    and administer your website via a {% include tooltip.html term-name="dedicated-server" text="dedicated server" %}, {% include tooltip.html term-name="virtual-private-server" text="virtual private server" %}, or {% include tooltip.html term-name="cloud-hosting" text="cloud-hosted server" %}, which you can access via {% include tooltip.html term-name="SSH" %}, and have the ability to {% include tooltip.html term-name="sudo" %}.
+    and administer your website via a {% include tooltip.html term-name="dedicated-server" text="dedicated server" %}, {% include tooltip.html term-name="virtual-private-server" text="virtual private server" %}, or {% include tooltip.html term-name="cloud-hosting" text="cloud-hosted server" %}, which you can access via {% include tooltip.html term-name="ssh" %}, and have the ability to {% include tooltip.html term-name="sudo" %}.
   </li>
 </ul>
 


### PR DESCRIPTION
Fix a glossary term that wasn't rendering properly on /about, swap an asset in the instructions generator