### PR TITLE
Update Trademark names

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -150,7 +150,7 @@
     "note": ""
   },
   {
-    "name": "WordPress",
+    "name": "WordPress.com",
     "link": "https://wordpress.com/",
     "category": "full",
     "tutorial": "",
@@ -490,7 +490,7 @@
     "note": ""
   },
   {
-    "name": "Dreamhost.com",
+    "name": "DreamHost",
     "link": "",
     "category": "partial",
     "tutorial": "",
@@ -670,7 +670,7 @@
     "note": ""
   },
   {
-    "name": "Gitlab",
+    "name": "GitLab",
     "link": "https://about.gitlab.com/",
     "category": "partial",
     "tutorial": "https://about.gitlab.com/2016/04/11/tutorial-securing-your-gitlab-pages-with-tls-and-letsencrypt/",
@@ -750,7 +750,7 @@
     "note": ""
   },
   {
-    "name": "Hostgator",
+    "name": "HostGator",
     "link": "",
     "category": "partial",
     "tutorial": "",


### PR DESCRIPTION
Update the case of DreamHost, HostGator, and GitLab.

Add `.com` to "WordPress" to specify this is different than the self-hosted version of the software found at WordPress.org and runs on many of the other hosts in the list.