### PR TITLE
Remove Ubuntu trusty instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -65,12 +65,6 @@
             "version": "16.04"
         },
         {
-            "name": "Ubuntu 14.04 (trusty)",
-            "id": "ubuntutrusty",
-            "distro": "ubuntu",
-            "version": "14.04"
-        },
-        {
             "name": "Ubuntu (other)",
             "id": "ubuntuother",
             "distro": "ububtu",


### PR DESCRIPTION
The system has reached its end-of-life for the public and trying to support the system will get harder and harder due to issues like pyca/cryptography#4923. This removes the system from the list of supported OSes.