### PR TITLE
Fix renewal and crontab instructions on debian jessie

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -22,7 +22,7 @@
   If you needed to stop your webserver to run Certbot, you'll want to edit the built-in command
   to add the <tt>--pre-hook</tt> and <tt>--post-hook</tt> flags to stop and start your
   webserver automatically. For example, if your webserver is HAProxy, add the following to the
-  <tt>certbot renew</tt> command:
+  <tt>{{base_command}} renew</tt> command:
 
   <pre>
     --pre-hook "service haproxy stop" --post-hook "service haproxy start"
@@ -43,17 +43,17 @@
   Set up automatic renewal
   <p>
   We recommend running the following line, which will add a cron job to the default crontab.
-  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; certbot renew" | sudo tee -a /etc/crontab > /dev/null</pre>
+  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew" | sudo tee -a /etc/crontab > /dev/null</pre>
   </p>
 
   {{#certonly}}
   <p>
   If you needed to stop your webserver to run Certbot, you'll want to
-  add <tt>--pre-hook</tt> and <tt>--post-hook</tt> flags after <tt>certbot renew</tt> to stop
+  add <tt>--pre-hook</tt> and <tt>--post-hook</tt> flags after <tt>{{base_command}} renew</tt> to stop
   and start your webserver automatically. For example, if your webserver is HAProxy, modify the
   command as follows:
 
-  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; certbot renew --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null</pre>
+  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null</pre>
   </p>
 
   <p>


### PR DESCRIPTION
On debian Jessie it is now recommended to use `certbot-auto`, but the renewal instructions still say `certbot`.  For manual commands the user will probably notice this and correct it, but the crontab command says `certbot` (not `certbot-auto`) and this will fail silently which could be Bad.
