### PR TITLE
Add Jimdo as hosting provider

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Jimdo",
+    "link": "https://www.jimdo.com/",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "https://www.jimdo.com/blog/secure-website-with-https/",
+    "plan": "",
+    "reviewed": "2019.7.05",
+    "note": ""
+  },
+  {
     "name": "Pantheon",
     "link": "https://pantheon.io/",
     "category": "full",


### PR DESCRIPTION
Hey,

Jimdo provides HTTPS automatically to all our customers, incl. custom domains. We partnered with Let'sEncrypt in 2016 and would be glad to be listed!

If you have any questions just let me know.

Cheers,
Simon