### PR TITLE
Use cloudflare as an example instead of RFC2136.

### DIFF
--- a/_scripts/instruction-widget/templates/install/dnspluginssetup.html
+++ b/_scripts/instruction-widget/templates/install/dnspluginssetup.html
@@ -7,9 +7,9 @@
     </p>
     <pre>{{install_command}} {{dns_package_prefix}}-&lt;PLUGIN&gt;</pre>
     <p>
-    For example, if your DNS provider is RFC2136, you'd run the following command:
+    For example, if your DNS provider is Cloudflare, you'd run the following command:
     </p>
-    <pre>{{install_command}} {{dns_package_prefix}}-rfc2136</pre>
+    <pre>{{install_command}} {{dns_package_prefix}}-cloudflare</pre>
 </li>
 <li>
     Set up credentials


### PR DESCRIPTION
As recently discussed, RFC2136 isn't a DNS provider, but an RFC for a protocol standard which we for some reason named our plugin after.

This PR updates the docs to use a different example.