### PR TITLE
Don't fail on broken hosting provider links

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gulp build certbot.",
   "scripts": {
-    "test": "htmlproofer ./_site --empty-alt-ignore true --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
+    "test": "htmlproofer ./_site --checks-to-ignore LinkCheck --empty-alt-ignore true && htmlproofer ./_site --checks-to-ignore ImageCheck,ScriptCheck --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
   },
   "dependencies": {
     "browser-sync": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gulp build certbot.",
   "scripts": {
-    "test": "htmlproofer ./_site --empty-alt-ignore true --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html,./_site/docs/api/log.html --allow-hash-href true"
+    "test": "htmlproofer ./_site --empty-alt-ignore true --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
   },
   "dependencies": {
     "browser-sync": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gulp build certbot.",
   "scripts": {
-    "test": "htmlproofer ./_site --checks-to-ignore LinkCheck --empty-alt-ignore true && htmlproofer ./_site --checks-to-ignore ImageCheck,ScriptCheck --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/search.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
+    "test": "htmlproofer ./_site --checks-to-ignore LinkCheck --empty-alt-ignore true --file-ignore ./_site/docs/search.html && htmlproofer ./_site --checks-to-ignore ImageCheck,ScriptCheck --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
   },
   "dependencies": {
     "browser-sync": "^2.19.0",


### PR DESCRIPTION
This fixes #455 by causing our tests to not check any of the links in the page at https://certbot.eff.org/hosting_providers/.

This is a slightly larger scope than we want, but I'm not aware of a way to only ignore links in the table itself. I personally think this is fine though.