### PR TITLE
Add RHEL 8 instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -107,6 +107,12 @@
             "version": "7"
         },
         {
+            "name": "RHEL 8",
+            "id": "centosrhel8",
+            "distro": "rhel",
+            "version": "8"
+        },
+        {
             "name": "FreeBSD",
             "id": "freebsd",
             "distro": "freebsd",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -88,11 +88,20 @@ module.exports = function(context) {
   centos_install = function() {
     template = "centos";
 
-    if (context.version < 7) {
+    // Certbot only has packages available for RHEL 7 based systems.
+    if (context.version != 7) {
       context.base_command = "/usr/local/bin/certbot-auto";
-      context.epel_auto = (context.distro == "centos");
+      // certbot-auto on CentOS 6 walks you through installing EPEL, but on
+      // RHEL 6 you need to do it beforehand. On RHEL 8 based systems, EPEL
+      // isn't needed at all.
+      if (context.version == 6 && context.distro == "rhel") {
+        context.need_epel = true;
+      } else {
+        context.need_epel = false;
+      }
       context.packaged = false;
     } else {
+      context.need_epel = true;
       context.base_command = "certbot";
       context.install_command = "sudo yum install";
       context.package = "certbot";

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -33,7 +33,7 @@
 {{/packaged}}
 
 {{^packaged}}
-{{^epel_auto}}
+{{#need_epel}}
 <li>
     Enable EPEL repo
     <p>
@@ -48,7 +48,7 @@
       enable EPEL</a>
     </p>
 </li>
-{{/epel_auto}}
+{{/need_epel}}
 {{>auto}}
 {{/packaged}}
 


### PR DESCRIPTION
Fixes https://github.com/certbot/website/issues/447.

We won't have packages available in RHEL 8 until EPEL 8 comes out which I'm told is likely months away so our latest Certbot release added certbot-auto support for RHEL 8 which people can use in the meantime.