### PR TITLE
Add CentOS 8 instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -113,9 +113,9 @@
             "version": "7"
         },
         {
-            "name": "RHEL 8",
+            "name": "CentOS/RHEL 8",
             "id": "centosrhel8",
-            "distro": "rhel",
+            "distro": "centos",
             "version": "8"
         },
         {


### PR DESCRIPTION
Fixes https://github.com/certbot/website/issues/475.

~~This should not be merged until Certbot 0.39.0 has been released.~~ This can be merged now.

I also changed the value of distro to "centos" for consistency with the previous entry in this file, but this change has no effect.