### PR TITLE
Providers: edit Online.net (partial to full)

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -120,6 +120,16 @@
     "note": ""
   },
   {
+    "name": "Online.net",
+    "link": "https://www.online.net/",
+    "category": "full",
+    "tutorial": "https://documentation.online.net/en/web/web-hosting/web-management/certificat-ssl",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2019.10.18",
+    "note": "Available on Web & Cloud hostings"
+  },
+  {
     "name": "Pantheon",
     "link": "https://pantheon.io/",
     "category": "full",
@@ -1321,16 +1331,6 @@
   },
   {
     "name": "one.com",
-    "link": "",
-    "category": "partial",
-    "tutorial": "",
-    "announcement": "",
-    "plan": "",
-    "reviewed": "",
-    "note": ""
-  },
-  {
-    "name": "Online.net",
     "link": "",
     "category": "partial",
     "tutorial": "",


### PR DESCRIPTION
According to [their documentation](https://documentation.online.net/en/web/web-hosting/web-management/certificat-ssl), Online.net automatically provisions certificates.  
They are applicable to their Web & Cloud hosting offers, natively supporting HTTPS.

I added the documentation link as a tutorial since it gives additional information.  
Feel free to edit it if it would be better as an announcement per example.