### PR TITLE
Don't tell people to use backports

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -134,14 +134,6 @@ module.exports = function(context) {
     } else if (context.webserver == "nginx") {
       context.package += " " + "python-certbot-nginx";
     }
-
-    if (context.version == 9) {
-      // Debian Stretch
-      context.backports_flag = "-t stretch-backports";
-    } else if (context.devuan && context.version == 2) {
-      // Devuan ASCII
-      context.backports_flag = "-t ascii-backports";
-    }
   }
 
   ubuntu_install = function() {

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -1,34 +1,5 @@
 {{> header}}
 
-{{#backports_flag}}
-{{#devuan}}
-<li>
-  Enable ASCII backports repo
-  <p>
-  You'll need to enable the ASCII backports repo in your APT sources. <br>
-  Follow these instructions at
-  <a href='https://devuan.org/os/etc/apt/sources.list#add-backports-default-no'>Devuan's site
-    to enable the ASCII backports repo</a>.
-  </p>
-  <p class="centered">
-    <a class="link-button" href='https://devuan.org/os/etc/apt/sources.list#add-backports-default-no'>enable the ASCII backports repo</a>
-  </p>
-</li>
-{{/devuan}}
-{{^devuan}}
-<li>
-  Enable Stretch backports repo
-  <p>
-  You'll need to enable Debian Strech's backports repo. <br>
-  Follow these instructions at <a href='http://backports.debian.org/Instructions/'>Debian's site
-    to enable the Stretch backports repo</a>.
-  </p>
-  <p class="centered">
-    <a class="link-button" href='http://backports.debian.org/Instructions/'>enable the Stretch backports repo</a>
-  </p>
-</li>
-{{/devuan}}
-{{/backports_flag}}
 {{>installcertbot}}
 
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/installcertbot.html
+++ b/_scripts/instruction-widget/templates/install/installcertbot.html
@@ -2,6 +2,6 @@
   Install Certbot
   <p>
     Run this command on the command line on the machine to install Certbot.
-    <pre>{{install_command}} {{package}} {{backports_flag}}</pre>
+    <pre>{{install_command}} {{package}}</pre>
   </p>
 </li>


### PR DESCRIPTION
This PR solves two issues by no longer telling people to use backports.

1. The packages in Debian Stretch and Devuan ASCII are newer than the versions in backports. Despite this, our current installation command forces the package to be installed from backports which doesn't have fixes for things such as always using POST-as-GET and people have to separately upgrade their packages to fix these problems.
2. Fixes https://github.com/certbot/website/issues/489.