### PR TITLE
Add Rocho DataCenter to host list

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2228,5 +2228,15 @@
     "plan": "",
     "reviewed": "2019.7.22",
     "note": ""
+  },
+  {
+    "name": "Rocho DataCenter",
+    "link": "https://www.rochodc.com",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2019.11.10",
+    "note": "The website is in French."
   }
 ]


### PR DESCRIPTION
Hi, Plesk is set to automatically enable HTTPS support by default with Let's Encrypt on all offers.