### PR TITLE
Add supported architecture warning

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -91,6 +91,12 @@ module.exports = function(context) {
     // Certbot only has packages available for RHEL 7 based systems.
     if (context.version != 7) {
       context.base_command = "/usr/local/bin/certbot-auto";
+      // RHEL/CentOS 6 32 bits distros are not supported by certbot-auto.
+      if (context.version == 6) {
+        context.deprecated_32bits = true
+      } else {
+        context.deprecated_32bits = false
+      }
       // certbot-auto on CentOS 6 walks you through installing EPEL, but on
       // RHEL 6 you need to do it beforehand. On RHEL 8 based systems, EPEL
       // isn't needed at all.

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,14 +1,13 @@
+{{#deprecated_32bits}}
 <aside class="note">
   <div class="note-header">
     <h3>Supported architectures:</h3>
   </div>
-  <p>We only support CentOS/RHEL 6 systems running on x86_64 architecture.</p>
+  <p>We only support CentOS/RHEL 6 systems running on x86_64 architecture. Pouet.</p>
 </aside>
-
+{{/deprecated_32bits}}
 
 {{> header}}
-
-
 
 {{#packaged}}
 <li>

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -3,7 +3,7 @@
   <div class="note-header">
     <h3>Supported architectures:</h3>
   </div>
-  <p>We only support CentOS/RHEL 6 systems running on x86_64 architecture. Pouet.</p>
+  <p>Certbot only supports CentOS/RHEL 6 systems running on the x86_64 architecture. To use Certbot on another architecture, you will need to upgrade your OS.</p>
 </aside>
 {{/deprecated_32bits}}
 

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,3 +1,11 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Supported architectures:</h3>
+  </div>
+  <p>We only support CentOS/RHEL 6 systems running on x86_64 architecture.</p>
+</aside>
+
+
 {{> header}}
 
 


### PR DESCRIPTION
Related to certbot/certbot#7587
Fixes certbot/certbot#7632
Fixes #512

This PR creates an information tooltip on top of RHEL 6 and CentOS 6 sections to warn users that non-x86_64 architectures are not supported by the team for these systems.