### PR TITLE
Add Wiktel to hosting providers list

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2278,5 +2278,15 @@
     "plan": "",
     "reviewed": "2020.01.07",
     "note": "Available for all plans from free account to dedicated servers"
+  },
+  {
+    "name": "Wikstrom Telephone Company (Wiktel)",
+    "link": "https://wiktel.com",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2020.01.16",
+    "note": "cPanel servers use cPanel's certificate system; all other sites use Let's Encrypt."
   }
 ]


### PR DESCRIPTION
Wikstrom Telephone Company (Wiktel) automatically uses Let's Encrypt
for all sites on shared hosting.

Edit: This is slightly misleading as originally worded. We automatically configure certificates on all sites on shared hosting. We use Let's Encrypt on the vast majority of them, but our cPanel server uses cPanel's system, which chains from Comodo.