### PR TITLE
Correct CentOS instructions

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -25,6 +25,7 @@ module.exports = function(context) {
     context.dns_plugins = false;
     context.dns_package_prefix = "";
     context.jessie = false;  // Special jessie instructions for certbot-auto
+    context.python_name = "python";
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
     if (context.webserver == "plesk" || context.distro == "nonunix" ||
@@ -96,15 +97,9 @@ module.exports = function(context) {
         context.deprecated_32bits = true
       } else {
         context.deprecated_32bits = false
+        context.python_name = "python3";
       }
-      // certbot-auto on CentOS 6 walks you through installing EPEL, but on
-      // RHEL 6 you need to do it beforehand. On RHEL 8 based systems, EPEL
-      // isn't needed at all.
-      if (context.version == 6 && context.distro == "rhel") {
-        context.need_epel = true;
-      } else {
-        context.need_epel = false;
-      }
+      context.need_epel = false;
       context.packaged = false;
     } else {
       context.need_epel = true;

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -44,7 +44,7 @@
   Set up automatic renewal
   <p>
   We recommend running the following line, which will add a cron job to the default crontab.
-  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew" | sudo tee -a /etc/crontab > /dev/null</pre>
+  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew" | sudo tee -a /etc/crontab > /dev/null</pre>
   </p>
 
   {{#certonly}}
@@ -54,7 +54,7 @@
   and start your webserver automatically. For example, if your webserver is HAProxy, modify the
   command as follows:
 
-  <pre class="one-line">echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null</pre>
+  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null</pre>
   </p>
 
   <p>


### PR DESCRIPTION
This PR corrects two things in our CentOS instructions:

1. On CentOS/RHEL 8 there apparently is no executable named "python" by default and at the very least we don't install one because certbot-auto uses "python3" on the platform. As a result our cron instructions to use "python" to sleep do not work. See https://community.letsencrypt.org/t/crontab-setup-on-centos-8-with-apache/111043.
2. With https://github.com/certbot/certbot/pull/7519, we no longer use EPEL on CentOS/RHEL 6 anymore so we shouldn't be telling RHEL 6 users to enable EPEL manually before running certbot-auto.