### PR TITLE
Add Platform.sh to hosting providers list

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -150,6 +150,16 @@
     "note": ""
   },
   {
+    "name": "Platform.sh",
+    "link": "https://platform.sh",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "https://docs.platform.sh/configuration/routes/https.html",
+    "reviewed": "2020.02.03",
+    "note": "All production and development environments include Let's Encrypt certificates automatically."
+  },
+  {
     "name": "Pride Tech Design",
     "link": "https://pridetechdesign.com/",
     "category": "full",


### PR DESCRIPTION
Platform.sh is a hosting provider that [automatically provides Let's Encrypt certificates](https://docs.platform.sh/configuration/routes/https.html) for all production and development environments. This pull request adds Platform.sh to the hosting providers list.