### PR TITLE
Update mydevil.net information

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1210,13 +1210,13 @@
     "note": ""
   },
   {
-    "name": "Mydevil.net",
-    "link": "",
+    "name": "MyDevil.net",
+    "link": "https://www.mydevil.net",
     "category": "partial",
-    "tutorial": "",
-    "announcement": "",
+    "tutorial": "https://wiki.mydevil.net/SSL",
+    "announcement": "https://www.mydevil.net/status,155,certyfikaty-lets-encrypt-http2-i-aktualizacja.html",
     "plan": "",
-    "reviewed": "",
+    "reviewed": "2020.2.7",
     "note": ""
   },
   {


### PR DESCRIPTION
This PR updates mydevil.net hosting provider with current info about Let's Encrypt certificates status.
I'm not sure whether it is a full or partial LE support as by default, vhosts have no SSL on the beginning and then You add SSL cert for that vhost- You have a combo box to upload cert files or generate them using LE.