### PR TITLE
Add Windows option to OS list

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -185,9 +185,9 @@
             "version": "0"
         },
         {
-            "name": "Non-UNIX",
-            "id": "nonunix",
-            "distro": "nonunix",
+            "name": "Windows",
+            "id": "windows",
+            "distro": "windows",
             "version": "0"
         }
     ]


### PR DESCRIPTION
I removed the Non-UNIX option since it seems like Windows should replace it, but let me know if that's not right. @maximillianh