### PR TITLE
Make instruction generator links use HTTPS

### DIFF
--- a/_scripts/instruction-widget/templates/install/macos.html
+++ b/_scripts/instruction-widget/templates/install/macos.html
@@ -3,10 +3,10 @@
     Install Homebrew
     <p>
     You'll need to install Homebrew.<br>
-    Follow these instructions at <a href='http://brew.sh/'>Homebrew's site to install Homebrew</a>.
+    Follow these instructions at <a href='https://brew.sh/'>Homebrew's site to install Homebrew</a>.
     </p>
     <p class="centered">
-    <a class="link-button" href='http://brew.sh/'>install Homebrew</a>
+    <a class="link-button" href='https://brew.sh/'>install Homebrew</a>
     </p>
 </li>
 {{>installcertbot}}

--- a/_scripts/main.js
+++ b/_scripts/main.js
@@ -15,7 +15,7 @@
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 var Raven = require('raven-js');


### PR DESCRIPTION
I noticed these http links while working on other stuff.

I didn't modify any links outside of the instruction generator because I'm less familiar with that code and there are a lot to check if they support HTTPS. We could always do that in a future PR if we wanted.