### PR TITLE
Fix link to other clients

### DIFF
--- a/_faq_entries/8-OS.md
+++ b/_faq_entries/8-OS.md
@@ -3,4 +3,4 @@ title:  "Does Certbot support my operating system?"
 weight: 8
 ---
 
-We currently have Certbot support for major Linux and BSD variant operating systems. There are a large number of other [client implementations](https://github.com/letsencrypt/letsencrypt/wiki/Links) available too.
+We currently have Certbot support for major Linux and BSD variant operating systems. There are a large number of other [client implementations](https://letsencrypt.org/docs/client-options/) available too.


### PR DESCRIPTION
https://github.com/letsencrypt/letsencrypt/wiki/Links redirects to the main page of our GitHub repo. Let's link to the list of other client implementations from Let's Encrypt instead.