### PR TITLE
Simplify OpenBSD instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -129,22 +129,10 @@
             "version": "0"
         },
         {
-            "name": "OpenBSD 5.9",
-            "id": "opbsd5",
-            "distro": "opbsd",
-            "version": "5.9"
-        },
-        {
             "name": "OpenBSD 6.0+",
             "id": "opbsd6",
             "distro": "opbsd",
             "version": "6"
-        },
-        {
-            "name": "OpenBSD (other)",
-            "id": "opbsd",
-            "distro": "auto",
-            "version": "0"
         },
         {
             "name": "macOS",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -213,13 +213,8 @@ module.exports = function(context) {
     }
     if (context.distro == "opbsd"){
       context.install_command = "pkg_add";
-      if (context.version >= 6) {
-          context.package = "certbot";
-          context.base_command = "certbot";
-      } else {
-          context.package = "letsencrypt";
-          context.base_command = "letsencrypt";
-      }
+      context.package = "certbot";
+      context.base_command = "certbot";
     }
 
     // The Apache plugin isn't packaged for BSD yet


### PR DESCRIPTION
Certbot is packaged in OpenBSD 6.0+. All versions older than that have been EOL'd see https://en.wikipedia.org/wiki/OpenBSD_version_history.

Let's remove the unnecessary documentation and code for unsupported versions of the OS.