### PR TITLE
Correct Apache/nginx FreeBSD instructions

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -220,13 +220,12 @@ module.exports = function(context) {
           context.package = "letsencrypt";
           context.base_command = "letsencrypt";
       }
-    }
-
-    // The Apache plugin isn't packaged for BSD yet
-    if (context.webserver == "apache") {
-      context.certonly = true;
-    } else if (context.webserver == "nginx") {
-      context.certonly = true;
+      // The Apache plugin isn't packaged for OpenBSD
+      if (context.webserver == "apache") {
+        context.certonly = true;
+      } else if (context.webserver == "nginx") {
+        context.certonly = true;
+      }
     }
   }
 


### PR DESCRIPTION
Our Apache and nginx plugins are available for FreeBSD. See https://www.freebsd.org/cgi/ports.cgi?query=certbot&stype=all.