### PR TITLE
Correct IRC channel

### DIFF
--- a/privacy/index.md
+++ b/privacy/index.md
@@ -35,6 +35,8 @@ In addition, you may elect to provide information to EFF through Certbot, such a
 
 EFF's Certbot Privacy Policy may change from time to time. However, any revised privacy policy will be consistent with EFF's mission. 
 
+*Updated on April 2nd, 2020 to change Freenode IRC channel.*
+
 *Updated on October 25th, 2018 to reflect changes to IRC services used.*
 
 *Updated on June 23rd, 2017 to add additional IRC services.*
@@ -42,6 +44,8 @@ EFF's Certbot Privacy Policy may change from time to time. However, any revised 
 *Updated on June 7th, 2017 to clarify which values are collected in the User Agent string.*
 
 #### Previous Privacy Policies
+
+[October 25, 2018 - April 2, 2020](https://github.com/certbot/website/blob/eedd40a1a55b0ac6b27a96adfb23e707356b834a/privacy/index.md)
 
 [June 23, 2017 - October 25, 2018](https://github.com/certbot/website/blob/446a47c51fb74db05b8240ddb24174a36e71cc82/privacy/index.md)
 

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -27,7 +27,7 @@ Let’s Encrypt also operates [Community Forums](https://community.letsencrypt.o
 
 Let’s Encrypt may change these policies or providers from time to time. If you have questions about Let’s Encrypt’s privacy practices, please contact them directly at [security@letsencrypt.org](mailto:security@letsencrypt.org).
 
-The Certbot community can be contacted through the Freenode Project’s IRC service, chat.freenode.net, on the #letsencrypt-dev channel. This IRC service is operated by Freenode, which does not publish a privacy policy.
+The Certbot community can be contacted through the Freenode Project’s IRC service, chat.freenode.net, on the #certbot-devel channel. This IRC service is operated by Freenode, which does not publish a privacy policy.
 
 In addition, you may elect to provide information to EFF through Certbot, such as your contact information or bug reports. That information will be protected by the [EFF Technology Project Privacy Policy](https://www.eff.org/code/privacy/policy).
 


### PR DESCRIPTION
This updates the IRC channel used in our privacy policy.

Maybe we also want to update this to reference our public mattermost instance? If so, I  can do that in this PR or we can do it later.

@maximillianh, this change is trivial, but since it's technically a change in our privacy policy, maybe we should have a lawyer take a look? I think you'll have better judgement here than me.