### PR TITLE
Default to certbot and fix macOS instructions

### DIFF
--- a/_scripts/instruction-widget/instructions.js
+++ b/_scripts/instruction-widget/instructions.js
@@ -12,9 +12,9 @@ module.exports = function() {
 
   // Set some defaults.
   var context = {
-    base_command: "letsencrypt",
-    base_package: "letsencrypt",
-    package: "letsencrypt",
+    base_command: "certbot",
+    base_package: "certbot",
+    package: "certbot",
   };
 
   get_partials = function(input) {


### PR DESCRIPTION
You can see the result of this change at https://github.com/certbot/website-builds/compare/836dd97ed43d0f71463090550c652c3070f5cb2b...0815ca3fc1281412987149829c9719681a819d07. The only change is to our macOS instructions where both letsencrypt and certbot work, but let's use Certbot.

All new packages should use the name certbot rather than letsencrypt, so fixing the default should prevent problems going forward.