### PR TITLE
Don't modify cron/systemd directly

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -24,12 +24,10 @@
   webserver is HAProxy, run the following commands:
   </p>
 
-  <pre>
-    sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'
-    sudo sh -c 'printf "#!/bin/sh\nservice haproxy start\n" > /etc/letsencrypt/renewal-hooks/post/haproxy.sh'
-    sudo chmod 755 /etc/letsencrypt/renewal-hooks/pre/haproxy.sh
-    sudo chmod 755 /etc/letsencrypt/renewal-hooks/post/haproxy.sh
-  </pre>
+  <pre class="no-before"><ol><li>sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'</li>
+    <li>sudo sh -c 'printf "#!/bin/sh\nservice haproxy start\n" > /etc/letsencrypt/renewal-hooks/post/haproxy.sh'</li>
+    <li>sudo chmod 755 /etc/letsencrypt/renewal-hooks/pre/haproxy.sh</li>
+    <li>sudo chmod 755 /etc/letsencrypt/renewal-hooks/post/haproxy.sh</li></ol></pre>
 
   <p>
   More information is available in the

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -19,14 +19,16 @@
 
   {{#certonly}}
   <p>
-  If you needed to stop your webserver to run Certbot, you'll want to edit the built-in command
-  to add the <tt>--pre-hook</tt> and <tt>--post-hook</tt> flags to stop and start your
-  webserver automatically. For example, if your webserver is HAProxy, add the following to the
-  <tt>{{base_command}} renew</tt> command:
+  If you needed to stop your webserver to run Certbot, you'll want to add hook
+  scripts to stop and start your webserver automatically. For example, if your
+  webserver is HAProxy, run the following commands:
   </p>
 
   <pre>
-    --pre-hook "service haproxy stop" --post-hook "service haproxy start"
+    sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'
+    sudo sh -c 'printf "#!/bin/sh\nservice haproxy start\n" > /etc/letsencrypt/renewal-hooks/post/haproxy.sh'
+    sudo chmod 755 /etc/letsencrypt/renewal-hooks/pre/haproxy.sh
+    sudo chmod 755 /etc/letsencrypt/renewal-hooks/post/haproxy.sh
   </pre>
 
   <p>


### PR DESCRIPTION
Instead of suggesting users modify their cron jobs or systemd timers directly, I think they should make use of the `renewal-hooks` directory, because if packages that set up these files want to make changes to them in the future, the OS package manager has to deal with conflicts. I'm not familiar with all the details on how each of them do this, especially if the package is upgraded non-interactively like is common in the case of snaps, but I think we can avoid these problems by making use of the `renewal-hooks` directory. It has the added benefit of allowing us to give exact (albeit more verbose) instructions that work everywhere.

This section now looks like:
![Screen Shot 2020-04-02 at 5 17 19 PM](https://user-images.githubusercontent.com/6504915/78311980-35706280-7507-11ea-9ac8-5811391d924e.png)

I left the information about the location of cron and systemd files as it's documentation for what's going on here, however, it's not necessary anymore and can be removed if we want.