### PR TITLE
Remove architecture warning from Docker instructions.

### DIFF
--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,3 +1,5 @@
+<!-- The advanced instructions don't use certbot-auto, so this warning isn't needed there. -->
+{{^advanced}}
 {{#deprecated_32bits}}
 <aside class="note">
   <div class="note-header">
@@ -6,6 +8,7 @@
   <p>Certbot only supports CentOS/RHEL 6 systems running on the x86_64 architecture. To use Certbot on another architecture, you will need to upgrade your OS.</p>
 </aside>
 {{/deprecated_32bits}}
+{{/advanced}}
 
 {{> header}}
 


### PR DESCRIPTION
If you go to https://certbot.eff.org/lets-encrypt/centos6-other and then select the tab for "wildcard", the warning about Certbot only x86_64 architectures being supported is shown. This isn't the intended behavior since the warning is specifically about certbot-auto. This PR removes the warning from that tab.