### PR TITLE
Fix newer Ubuntu instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -64,7 +64,7 @@
         },
         {
             "name": "Ubuntu 19.10+",
-            "id": "ubuntueoan",
+            "id": "ubuntuother",
             "distro": "ubuntu",
             "version": "19.10"
         },

--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -63,6 +63,12 @@
             "version": "0"
         },
         {
+            "name": "Ubuntu 19.10+",
+            "id": "ubuntueoan",
+            "distro": "ubuntu",
+            "version": "19.10"
+        },
+        {
             "name": "Ubuntu 18.04 LTS (bionic)",
             "id": "ubuntubionic",
             "distro": "ubuntu",
@@ -73,12 +79,6 @@
             "id": "ubuntuxenial",
             "distro": "ubuntu",
             "version": "16.04"
-        },
-        {
-            "name": "Ubuntu (other)",
-            "id": "ubuntuother",
-            "distro": "ububtu",
-            "version": "0"
         },
         {
             "name": "Gentoo",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -140,6 +140,7 @@ module.exports = function(context) {
   ubuntu_install = function() {
     template = "ubuntu";
 
+    context.ppa = context.version < 19.10;
     context.package = "certbot";
     context.install_command = "sudo apt-get install";
     if (context.webserver == "apache") {

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,5 +1,6 @@
 {{> header}}
 
+{{#ppa}}
 <li>
     Add Certbot PPA
     <p>
@@ -12,6 +13,7 @@
       <li>sudo apt-get update</li></ol></pre>
     </p>
 </li>
+{{/ppa}}
 
 {{> installcertbot}}
 {{> dnspluginssetup}}


### PR DESCRIPTION
Fixes https://github.com/certbot/website/issues/501.

I think this issue has increased in priority because Ubuntu 20.04 will be out soon and I believe it will not contain Python 2 meaning that our current instructions for the platform (found under the "Ubuntu (other)" dropdown) won't work because certbot-auto will assume that Python 2 is available. Let's tell people to just use the OS packages instead and avoid confusion/bug reports about this.

I kept the `id` as `ubuntuother` to prevent any links to those instructions from breaking.