### PR TITLE
Remove link to gantt chart

### DIFF
--- a/_includes/contrib/main_list.html
+++ b/_includes/contrib/main_list.html
@@ -14,7 +14,7 @@
   <li class="mm-bullet">
     Chat with us about where we need help
     <p>
-    If you’re a software developer, come talk to us on <a href='https://opensource.eff.org/eff-open-source/channels/certbot'>Mattermost</a> (see above). The team focuses on a few issues at a time, so it’s best to check in with us. <a href='https://prod.teamgantt.com/gantt/schedule/?ids=1448179&public_keys=1yuNAQqvEfSv&zoom=d100&font_size=12&estimated_hours=0&assigned_resources=0&percent_complete=0&documents=0&comments=0&col_width=355&hide_header_tabs=0&menu_view=1&resource_filter=1&name_in_bar=0&name_next_to_bar=0&resource_names=1#user=&company=&custom=&date_filter=&hide_completed=false&color_filter=&ids=1448179'>Check out the current topics we’re working on</a>.
+    If you’re a software developer, come talk to us on <a href='https://opensource.eff.org/eff-open-source/channels/certbot'>Mattermost</a> (see above). The team focuses on a few issues at a time, so it’s best to check in with us.
     </p>
   </li>
   <li class="mm-bullet">


### PR DESCRIPTION
This gantt chart is no longer being updated so let's remove the link.

We could alternatively, try to link to our [milestones](https://github.com/certbot/certbot/milestones), however, I'm not immediately sure how to make it clear to outsiders which milestones are relevant. If we do something like this, I'd prefer if it was done in a separate PR. My main goal here was just to remove the bad information.