### PR TITLE
Use python3 packages directly on Ubuntu

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -147,9 +147,9 @@ module.exports = function(context) {
     context.package = "certbot";
     context.install_command = "sudo apt-get install";
     if (context.webserver == "apache") {
-      context.package += " " + "python-certbot-apache";
+      context.package += " " + "python3-certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.package += " " + "python-certbot-nginx";
+      context.package += " " + "python3-certbot-nginx";
     }
     // Debian Jessie, Ubuntu 16.10, or newer
     context.base_command = "certbot";


### PR DESCRIPTION
For a long time in Debian/Ubuntu, the `python-certbot-*` packages were just wrappers around the `python3` package. For instance, [here](https://packages.ubuntu.com/eoan/python-certbot-nginx) is the package for `python-certbot-nginx` on Ubuntu 19.10. Notice its only dependency is `python3-certbot-nginx`.

Apparently, Ubuntu 20.04 removed these dummy packages so our current installation instructions for the Apache/Nginx plugin don't work on the system. This PR fixes that.

It's safe to change all of our Ubuntu instructions because the PPA does the same thing. Here's relevant output from Ubuntu 16.04:
```
# apt-cache show python-certbot-nginx 
Package: python-certbot-nginx
Priority: optional
Section: oldlibs
Installed-Size: 13
Maintainer: Debian Let's Encrypt <team+letsencrypt@tracker.debian.org>
Architecture: all
Version: 0.31.0-1+ubuntu16.04.1+certbot+1
Depends: python3-certbot-nginx
Filename: pool/main/p/python-certbot-nginx/python-certbot-nginx_0.31.0-1+ubuntu16.04.1+certbot+1_all.deb
Size: 2982
MD5sum: aa8cb12c7f1f7265662b0d2242ef0638
SHA1: 62a554e78b3f0c03442fdf3f65c16a7e02975b5b
SHA256: f4d4ae39678394e4014b03c1b9e56fd975fb9d9c7dfe4cab9e737c916ca311a7
Description: transitional dummy package
Description-md5: fa49bab931274861c23fc8ebfeed6bf8
```