### PR TITLE
Fix Namecheap hosting tutorial

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2212,12 +2212,12 @@
   {
     "name": "Namecheap.com",
     "link": "https://www.namecheap.com/hosting/",
-    "category": "partial",
+    "category": "no",
     "tutorial": "https://www.namecheap.com/support/knowledgebase/article.aspx/9418/33/installing-an-ssl-certificate-on-your-server-using-cpanel/",
     "announcement": "",
     "plan": "https://community.letsencrypt.org/t/namecheap-response-to-lets-encrypt/51411",
     "reviewed": "2020.4.27",
-    "note": "automatic renewal via ACME not offically supported"
+    "note": ""
   },
   {
     "name": "Netsons.com",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2215,7 +2215,7 @@
     "category": "no",
     "tutorial": "https://www.namecheap.com/support/knowledgebase/article.aspx/9418/33/installing-an-ssl-certificate-on-your-server-using-cpanel/",
     "announcement": "",
-    "plan": "https://community.letsencrypt.org/t/namecheap-response-to-lets-encrypt/51411",
+    "plan": "",
     "reviewed": "2020.4.27",
     "note": ""
   },

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2211,13 +2211,13 @@
   },
   {
     "name": "Namecheap.com",
-    "link": "https://www.namecheap.com/security/ssl-certificates/",
+    "link": "https://www.namecheap.com/hosting/",
     "category": "partial",
-    "tutorial": "https://www.namecheap.com/blog/install-free-ssls/",
+    "tutorial": "https://www.namecheap.com/support/knowledgebase/article.aspx/9418/33/installing-an-ssl-certificate-on-your-server-using-cpanel/",
     "announcement": "",
-    "plan": "https://www.namecheap.com/security/ssl-certificates/",
-    "reviewed": "2019.6.6",
-    "note": ""
+    "plan": "https://community.letsencrypt.org/t/namecheap-response-to-lets-encrypt/51411",
+    "reviewed": "2020.4.27",
+    "note": "automatic renewal via ACME not offically supported"
   },
   {
     "name": "Netsons.com",


### PR DESCRIPTION
I hope this proves useful to others.

I have attached the "long-winded" explanation of my proposed changes in the commit message; the "tldr" of which is:

* _None_ of the previous links were even _applicable_ to Let's Encrypt.
* Most of them were _only_ applicable to "Namecheap SSL", a branded, paid product from their partner, Codomo.
* I have replaced _all_ these links with both applicable and informative URLs.