### PR TITLE
One.com supplys wildcard letsencrypt for all webhosting customers.

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1371,12 +1371,12 @@
   },
   {
     "name": "one.com",
-    "link": "",
-    "category": "partial",
+    "link": "https://www.one.com/",
+    "category": "full",
     "tutorial": "",
     "announcement": "",
     "plan": "",
-    "reviewed": "",
+    "reviewed": "2020.4.29",
     "note": ""
   },
   {


### PR DESCRIPTION
More info at: https://help.one.com/hc/en-us/articles/115005587449-How-do-I-manage-SSL-for-my-website-

One.com use DNS validation and requires that that the _acme-challenge points to one.com nameservers.
It's possible for customers to use non-one.com nameservers by adding a cname:

https://help.one.com/hc/en-us/articles/360000297458-Why-is-SSL-HTTPS-not-working-on-my-site-#step-5