### PR TITLE
Make sure universe is enabled in non-PPA Ubuntu instructions

### DIFF
--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -22,6 +22,7 @@
       <li>sudo apt-get install software-properties-common</li>
       <li>sudo add-apt-repository universe</li>
       <li>sudo apt-get update</li></ol></pre>
+    </p>
 {{/ppa}}
 </li>
 

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,7 +1,7 @@
 {{> header}}
 
-<li>
 {{#ppa}}
+<li>
     Add Certbot PPA
     <p>
     You'll need to add the Certbot PPA to your list of repositories. To do so,
@@ -12,8 +12,10 @@
       <li>sudo add-apt-repository ppa:certbot/certbot</li>
       <li>sudo apt-get update</li></ol></pre>
     </p>
+</li>
 {{/ppa}}
 {{^ppa}}
+<li>
     Enable the universe repository
     <p>
     You'll need to make sure Ubuntu universe is in your list of repositories.
@@ -23,8 +25,8 @@
       <li>sudo add-apt-repository universe</li>
       <li>sudo apt-get update</li></ol></pre>
     </p>
-{{/ppa}}
 </li>
+{{/ppa}}
 
 {{> installcertbot}}
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,25 +1,28 @@
 {{> header}}
 
 <li>
-    {{#ppa}}
+{{#ppa}}
     Add Certbot PPA
     <p>
-    You'll need to add the Certbot PPA to your list of repositories.
-    {{/ppa}}
-    {{^ppa}}
+    You'll need to add the Certbot PPA to your list of repositories. To do so,
+    run the following commands on the command line on the machine:
+    <pre class="no-before"><ol><li>sudo apt-get update</li>
+      <li>sudo apt-get install software-properties-common</li>
+      <li>sudo add-apt-repository universe</li>
+      <li>sudo add-apt-repository ppa:certbot/certbot</li>
+      <li>sudo apt-get update</li></ol></pre>
+    </p>
+{{/ppa}}
+{{^ppa}}
     Enable the universe repository
     <p>
     You'll need to make sure Ubuntu universe is in your list of repositories.
-    {{/ppa}}
     To do so, run the following commands on the command line on the machine:
     <pre class="no-before"><ol><li>sudo apt-get update</li>
       <li>sudo apt-get install software-properties-common</li>
       <li>sudo add-apt-repository universe</li>
-      {{#ppa}}
-      <li>sudo add-apt-repository ppa:certbot/certbot</li>
       <li>sudo apt-get update</li></ol></pre>
-      {{/ppa}}
-    </p>
+{{/ppa}}
 </li>
 
 {{> installcertbot}}

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,19 +1,26 @@
 {{> header}}
 
-{{#ppa}}
 <li>
+    {{#ppa}}
     Add Certbot PPA
     <p>
-    You'll need to add the Certbot PPA to your list of repositories. To do so,
-    run the following commands on the command line on the machine:
+    You'll need to add the Certbot PPA to your list of repositories.
+    {{/ppa}}
+    {{^ppa}}
+    Enable the universe repository
+    <p>
+    You'll need to make sure Ubuntu universe is in your list of repositories.
+    {{/ppa}}
+    To do so, run the following commands on the command line on the machine:
     <pre class="no-before"><ol><li>sudo apt-get update</li>
       <li>sudo apt-get install software-properties-common</li>
       <li>sudo add-apt-repository universe</li>
+      {{#ppa}}
       <li>sudo add-apt-repository ppa:certbot/certbot</li>
       <li>sudo apt-get update</li></ol></pre>
+      {{/ppa}}
     </p>
 </li>
-{{/ppa}}
 
 {{> installcertbot}}
 {{> dnspluginssetup}}


### PR DESCRIPTION
As reported at https://github.com/certbot/certbot/issues/7953, our non-PPA Ubuntu instructions don't work if Ubuntu's universe repository isn't enabled. (If you're unfamiliar with the different components of Ubuntu's repos, you can find a short summary at the top of https://help.ubuntu.com/community/Repositories/Ubuntu).

Universe seems to be enabled by default in most places, but this change makes our instructions work even if it's not enabled.

Our non-PPA Ubuntu instructions are unchanged and the new instructions for 19.10+ look like 
![Screen Shot 2020-04-28 at 11 26 54 AM](https://user-images.githubusercontent.com/6504915/80523963-bcb4c880-8943-11ea-984f-8c4b99192400.png)
