### PR TITLE
Do not use our nginx plugin until it is fixed

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -69,7 +69,13 @@
             "version": "0"
         },
         {
-            "name": "Ubuntu 19.10+",
+            "name": "Ubuntu 20.04",
+            "id": "ubuntufocal",
+            "distro": "ubuntu",
+            "version": "20.04"
+        },
+        {
+            "name": "Ubuntu 19.10",
             "id": "ubuntuother",
             "distro": "ubuntu",
             "version": "19.10"

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -149,7 +149,14 @@ module.exports = function(context) {
     if (context.webserver == "apache") {
       context.package += " " + "python3-certbot-apache";
     } else if (context.webserver == "nginx") {
-      context.package += " " + "python3-certbot-nginx";
+      // The nginx plugin is currently broken in Ubuntu 20.04 (and newer
+      // unreleased versions) due to the bug described at
+      // https://bugs.launchpad.net/ubuntu/+source/python-certbot-nginx/+bug/1875471/.
+      if (context.version > 19.10) {
+        context.certonly = true;
+      } else {
+        context.package += " " + "python3-certbot-nginx";
+      }
     }
     // Debian Jessie, Ubuntu 16.10, or newer
     context.base_command = "certbot";


### PR DESCRIPTION
Fixes #570 with the design agreed upon there.

The Ubuntu 19.10 nginx instructions look like
![Screen Shot 2020-04-28 at 5 21 29 PM](https://user-images.githubusercontent.com/6504915/80551018-dde2dc80-8976-11ea-9d7f-1daff4dc6b2c.png)

The Ubuntu 20.04 nginx instructions look like
![Screen Shot 2020-04-28 at 5 21 39 PM](https://user-images.githubusercontent.com/6504915/80551022-dfaca000-8976-11ea-9898-f084d99ba721.png)

