### PR TITLE
Rename UnoEuro to Simply.com

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1820,13 +1820,13 @@
     "note": ""
   },
   {
-    "name": "UnoEuro",
+    "name": "Simply.com",
     "link": "",
     "category": "partial",
-    "tutorial": "https://en.unoeuro.com/support/faq/general/557/",
+    "tutorial": "https://www.simply.com/en/support/faq/46/557/",
     "announcement": "",
     "plan": "",
-    "reviewed": "2019.6.6",
+    "reviewed": "2020.5.4",
     "note": ""
   },
   {


### PR DESCRIPTION
Updated name and tutorial link as UnoEuro recently changed its name to Simply.com