### PR TITLE
Have CentOS/RHEL 8 users use EPEL 8 instead of certbot-auto

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -89,8 +89,8 @@ module.exports = function(context) {
   centos_install = function() {
     template = "centos";
 
-    // Certbot only has packages available for RHEL 7 based systems.
-    if (context.version != 7) {
+    // Certbot only has packages available for RHEL 7+ based systems.
+    if (context.version < 7) {
       context.base_command = "/usr/local/bin/certbot-auto";
       // RHEL/CentOS 6 32 bits distros are not supported by certbot-auto.
       if (context.version == 6) {
@@ -104,17 +104,25 @@ module.exports = function(context) {
     } else {
       context.need_epel = true;
       context.base_command = "certbot";
-      context.install_command = "sudo yum install";
       context.package = "certbot";
       context.packaged = true;
 
+      if (context.version == 7) {
+        context.install_command = "sudo yum install";
+        python_prefix = "python2-"
+      } else {
+        context.install_command = "sudo dnf install";
+        python_prefix = "python3-"
+      }
+
+
       if (context.webserver == "apache") {
-        context.package += " python2-certbot-apache";
+        context.package += " " + python_prefix + "certbot-apache";
       } else if (context.webserver == "nginx") {
-        context.package += " python2-certbot-nginx";
+        context.package += " " + python_prefix + "certbot-nginx";
       }
       context.dns_plugins = true;
-      context.dns_package_prefix = "python2-certbot-dns";
+      context.dns_package_prefix = python_prefix + "certbot-dns";
     }
   }
 

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -14,7 +14,9 @@
     Enable EPEL repo
     <p>
     You'll need to enable the EPEL (Extra Packages for Enterprise Linux)
-    repository.<br>
+    repository and make sure you follow all instructions for your system,
+    including enabling any other recommended repositories that may be
+    required.<br>
     Follow these instructions at
     <a href='https://fedoraproject.org/wiki/EPEL#Quickstart'>
       the Fedora wiki to enable EPEL</a>.

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -16,22 +16,12 @@
     You'll need to enable the EPEL (Extra Packages for Enterprise Linux)
     repository.<br>
     Follow these instructions at
-    <a href='https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F'>
+    <a href='https://fedoraproject.org/wiki/EPEL#Quickstart'>
       the Fedora wiki to enable EPEL</a>.
     </p>
     <p class="centered">
-    <a class="link-button" href='https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F'>
+    <a class="link-button" href='https://fedoraproject.org/wiki/EPEL#Quickstart'>
       enable EPEL</a>
-    </p>
-</li>
-<li>
-    Enable the optional channel
-    <p>
-    If you're using RHEL or Oracle Linux, you'll also need to enable the optional channel.
-    On EC2, RHEL users can enable the optional channel by running the following command,
-    substituting your EC2 region for REGION in the command:
-    <pre class="no-before"><ol><li>yum -y install yum-utils</li>
-      <li>yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-REGION-rhel-server-optional</li></ol></pre>
     </p>
 </li>
 
@@ -40,22 +30,6 @@
 {{/packaged}}
 
 {{^packaged}}
-{{#need_epel}}
-<li>
-    Enable EPEL repo
-    <p>
-    You'll need to enable the EPEL (Extra Packages for Enterprise Linux)
-    repository to download Certbot's dependecies.<br>
-    Follow these instructions at
-    <a href='https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F'>
-      the Fedora wiki to enable EPEL</a>.
-    </p>
-    <p class="centered">
-    <a class="link-button" href='https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F'>
-      enable EPEL</a>
-    </p>
-</li>
-{{/need_epel}}
 {{>auto}}
 {{/packaged}}
 


### PR DESCRIPTION
Fixes #492.

As part of this PR, I generalized our EPEL instructions since the instructions are different for EPEL 7 and EPEL 8 and our EPEL 7 instructions were out-of-date according to https://fedoraproject.org/wiki/EPEL#Quickstart.

I also removed the section about installing EPEL when you're not using OS packages rather than also updating the links there since it's dead code since we stopped using EPEL 6 in certbot-auto.