### PR TITLE
Remove "Debian (other)" option

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -63,12 +63,6 @@
             "version": "11"
         },
         {
-            "name": "Debian (other)",
-            "id": "debianother",
-            "distro": "debian",
-            "version": "0"
-        },
-        {
             "name": "Ubuntu 20.04",
             "id": "ubuntufocal",
             "distro": "ubuntu",


### PR DESCRIPTION
Currently we have dropdown options for every non-EOL'd version of Debian as well as an option for "Debian (other)". Since we have explicit dropdowns for each supported version of Debian, I don't think we need another catch all one so this PR removes it.

I started to try and get a redirect set up from the "Debian (other)" URLs, but the instructions use certbot-auto which we're trying to deprecate and the only other Debian dropdown that uses certbot-auto is Debian 8 which is EOL'd next month. Because of this, my preference is to do the simple thing and let links to the soon to be outdated instructions break.