### PR TITLE
CSS workaround for list styling in Windows documentation

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -13,7 +13,7 @@ able to use to obtain a certificate from Let's Encrypt.
 <p>
 This procedure follows the current Certbot implementation for Windows, in particular the fact that it installs as a system component, and requires administrative privileges. These instructions will be updated when a future version of Certbot <a href="https://github.com/certbot/certbot/issues/7883">switches to a different installation method</a>.
 No installers for HTTP servers are supported for now (Certbot for Windows can currently obtain your certificate from
-Let's Encrypt, but not install it into your web server application).
+Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows system requirements and user knowledge requirements</h2>
 
@@ -104,7 +104,7 @@ Let's Encrypt, but not install it into your web server application).
   <a href='https://www.ssllabs.com/ssltest/'>https://www.ssllabs.com/ssltest/</a>.
   </p>
   <p class="centered">
-  <a class="link-button" href='https://www.ssllabs.com/ssltest/'>check your site's <img src="/images/Lock.svg"> https:// at SSL Labs</a>.
+  <a class="link-button" href='https://www.ssllabs.com/ssltest/'>check your site's <img src="/images/Lock.svg" /> https:// at SSL Labs</a>.
   </p>
 
 <h2>Note for Windows Apache or Nginx users</h2>

--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -40,7 +40,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 <ol>
 <li>Connect locally or remotely (using Remote Desktop) to the server using an account that has administrative privileges for this machine.</li>
 </ol>
-<li>Install Certbot.
+<li>Install Certbot.</li>
 <ol>
 	<li>Download the latest version of the Certbot installer for Windows at <a class="reference external" href="https://dl.eff.org/certbot-beta-installer-win32.exe">https://dl.eff.org/certbot-beta-installer-win32.exe</a>.</li>
 	<li>Run the installer and follow the wizard. The installer will propose a default installation directory, <code>C:\Program Files(x86)</code>, that can be customized.)</li>

--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -1,5 +1,5 @@
 <!-- Added styles list-style-type:initial and font-size:initial to override main.css rules
-	on lists that were producing unintended effects here.  Also redundant font-size:11px
+	on lists that were producing unintended effects here.  Also redundant font-size:16px
 	and list-style-type:disc in case people visit with MSIE and don't have "initial". -->
 <h1>Windows installation procedure</h1>
 
@@ -20,7 +20,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows system requirements and user knowledge requirements</h2>
 
-<ul style="font-size: 11px; list-style-type: disc; font-size: initial; list-style-type: initial">
+<ul style="font-size: 16px; list-style-type: disc; font-size: initial; list-style-type: initial">
 <li>The user needs to be familiar with the command-line interface (CLI), because Certbot is a pure CLI program.</li>
 <li>The user must use an account with administrative privileges to install and run Certbot.</li>
 <li>PowerShell and <code>CMD.EXE</code> are supported; both need to be started with elevated privileges before invoking Certbot.</li>
@@ -29,7 +29,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows limitations and configuration</h2>
 
-<ul style="font-size: 11px; list-style-type: disc; font-size: initial; list-style-type: initial">
+<ul style="font-size: 16px; list-style-type: disc; font-size: initial; list-style-type: initial">
 <li>All usual operations to create and manage an account, manage existing certificates, or select the ACME server, are supported.</li>
 <li>Only standalone, manual and webroot authenticator plugins are supported. DNS plugins will be available soon. This means that Certbot for Windows is currently unable to automatically renew wildcard certificates, since these require a DNS plugin in order to be renewed without user intervention.</li>
 <li>No installer plugins are supported. The Apache and Nginx plugins will be available soon, and a plugin to install certificates into IIS is under development.</li>
@@ -38,13 +38,13 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Installation instructions (default)</h2>
 
-<ol class="arabic simple" style="font-size: 11px; font-size: initial">
+<ol class="arabic simple" style="font-size: 16px; font-size: initial">
 <li>Connect to the server.</li>
-<ol style="font-size: 11px; font-size: initial">
+<ol style="font-size: 16px; font-size: initial">
 <li>Connect locally or remotely (using Remote Desktop) to the server using an account that has administrative privileges for this machine.</li>
 </ol>
 <li>Install Certbot.</li>
-<ol style="font-size: 11px; font-size: initial">
+<ol style="font-size: 16px; font-size: initial">
 	<li>Download the latest version of the Certbot installer for Windows at <a class="reference external" href="https://dl.eff.org/certbot-beta-installer-win32.exe">https://dl.eff.org/certbot-beta-installer-win32.exe</a>.</li>
 	<li>Run the installer and follow the wizard. The installer will propose a default installation directory, <code>C:\Program Files(x86)</code>, that can be customized.)</li>
 </ol>

--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -1,5 +1,6 @@
 <!-- Added styles list-style-type:initial and font-size:initial to override main.css rules
-	on lists that were producing unintended effects here. -->
+	on lists that were producing unintended effects here.  Also redundant font-size:11px
+	and list-style-type:disc in case people visit with MSIE and don't have "initial". -->
 <h1>Windows installation procedure</h1>
 
 <p>
@@ -19,7 +20,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows system requirements and user knowledge requirements</h2>
 
-<ul style="font-size: initial; list-style-type: initial">
+<ul style="font-size: 11px; list-style-type: disc; font-size: initial; list-style-type: initial">
 <li>The user needs to be familiar with the command-line interface (CLI), because Certbot is a pure CLI program.</li>
 <li>The user must use an account with administrative privileges to install and run Certbot.</li>
 <li>PowerShell and <code>CMD.EXE</code> are supported; both need to be started with elevated privileges before invoking Certbot.</li>
@@ -28,7 +29,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows limitations and configuration</h2>
 
-<ul style="font-size: initial; list-style-type: initial">
+<ul style="font-size: 11px; list-style-type: disc; font-size: initial; list-style-type: initial">
 <li>All usual operations to create and manage an account, manage existing certificates, or select the ACME server, are supported.</li>
 <li>Only standalone, manual and webroot authenticator plugins are supported. DNS plugins will be available soon. This means that Certbot for Windows is currently unable to automatically renew wildcard certificates, since these require a DNS plugin in order to be renewed without user intervention.</li>
 <li>No installer plugins are supported. The Apache and Nginx plugins will be available soon, and a plugin to install certificates into IIS is under development.</li>
@@ -37,13 +38,13 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Installation instructions (default)</h2>
 
-<ol class="arabic simple" style="font-size: initial">
+<ol class="arabic simple" style="font-size: 11px; font-size: initial">
 <li>Connect to the server.</li>
-<ol style="font-size: initial">
+<ol style="font-size: 11px; font-size: initial">
 <li>Connect locally or remotely (using Remote Desktop) to the server using an account that has administrative privileges for this machine.</li>
 </ol>
 <li>Install Certbot.</li>
-<ol style="font-size: initial">
+<ol style="font-size: 11px; font-size: initial">
 	<li>Download the latest version of the Certbot installer for Windows at <a class="reference external" href="https://dl.eff.org/certbot-beta-installer-win32.exe">https://dl.eff.org/certbot-beta-installer-win32.exe</a>.</li>
 	<li>Run the installer and follow the wizard. The installer will propose a default installation directory, <code>C:\Program Files(x86)</code>, that can be customized.)</li>
 </ol>

--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -1,3 +1,5 @@
+<!-- Added styles list-style-type:initial and font-size:initial to override main.css rules
+	on lists that were producing unintended effects here. -->
 <h1>Windows installation procedure</h1>
 
 <p>
@@ -17,7 +19,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows system requirements and user knowledge requirements</h2>
 
-<ul>
+<ul style="font-size: initial; list-style-type: initial">
 <li>The user needs to be familiar with the command-line interface (CLI), because Certbot is a pure CLI program.</li>
 <li>The user must use an account with administrative privileges to install and run Certbot.</li>
 <li>PowerShell and <code>CMD.EXE</code> are supported; both need to be started with elevated privileges before invoking Certbot.</li>
@@ -26,7 +28,7 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Specific Windows limitations and configuration</h2>
 
-<ul>
+<ul style="font-size: initial; list-style-type: initial">
 <li>All usual operations to create and manage an account, manage existing certificates, or select the ACME server, are supported.</li>
 <li>Only standalone, manual and webroot authenticator plugins are supported. DNS plugins will be available soon. This means that Certbot for Windows is currently unable to automatically renew wildcard certificates, since these require a DNS plugin in order to be renewed without user intervention.</li>
 <li>No installer plugins are supported. The Apache and Nginx plugins will be available soon, and a plugin to install certificates into IIS is under development.</li>
@@ -35,13 +37,13 @@ Let's Encrypt, but not install it into your web server application).</p>
 
 <h2>Installation instructions (default)</h2>
 
-<ol class="arabic simple">
+<ol class="arabic simple" style="font-size: initial">
 <li>Connect to the server.</li>
-<ol>
+<ol style="font-size: initial">
 <li>Connect locally or remotely (using Remote Desktop) to the server using an account that has administrative privileges for this machine.</li>
 </ol>
 <li>Install Certbot.</li>
-<ol>
+<ol style="font-size: initial">
 	<li>Download the latest version of the Certbot installer for Windows at <a class="reference external" href="https://dl.eff.org/certbot-beta-installer-win32.exe">https://dl.eff.org/certbot-beta-installer-win32.exe</a>.</li>
 	<li>Run the installer and follow the wizard. The installer will propose a default installation directory, <code>C:\Program Files(x86)</code>, that can be customized.)</li>
 </ol>


### PR DESCRIPTION
This uses a couple of explicit CSS styles to return two properties related to list tags to their default values, just for individual list elements (`<ul>` and `<ol>`) in the Windows documentation.

This is not a general solution to the formatting problem, but I don't understand enough about CSS and the styles for the instruction generator to know what the author's intentions were (e.g. to use a specific `class` for lists inside instruction templates?).