### PR TITLE
Remove reference to the advanced tab

### DIFF
--- a/_scripts/instruction-widget/instructions.js
+++ b/_scripts/instruction-widget/instructions.js
@@ -39,9 +39,7 @@ module.exports = function() {
         (input.version == null) ||
         (input.webserver == null)) {
       return 'To get instructions for Certbot, choose your server software ' +
-        'and the system it is running on from the dropdown menus above. ' +
-        'You can then pick "advanced" if you want less automation and more ' +
-        'control.';
+        'and the system it is running on from the dropdown menus above.';
     }
     var partials = get_partials(input);
     var template = require("./templates/instructions.html")


### PR DESCRIPTION
We don't have an advanced tab anymore. Instead, we have a wildcard tab.

We could talk about the wildcard tab here instead if we wanted, but my goal with this PR was just to quickly fix the out of date instructions I noticed.