### PR TITLE
Remove Debian 8 instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -39,12 +39,6 @@
             "version": "0"
         },
         {
-            "name": "Debian 8 (jessie)",
-            "id": "debianjessie",
-            "distro": "debian",
-            "version": "8"
-        },
-        {
             "name": "Debian 9 (stretch)",
             "id": "debianstretch",
             "distro": "debian",
@@ -151,12 +145,6 @@
             "id": "devuanascii",
             "distro": "devuan",
             "version": "2"
-        },
-        {
-            "name": "Devuan Jessie 1.0",
-            "id": "devuanjessie",
-            "distro": "devuan",
-            "version": "1"
         },
         {
             "name": "Devuan testing/unstable",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -24,7 +24,6 @@ module.exports = function(context) {
     context.cron_included = false;
     context.dns_plugins = false;
     context.dns_package_prefix = "";
-    context.jessie = false;  // Special jessie instructions for certbot-auto
     context.python_name = "python";
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
@@ -67,9 +66,6 @@ module.exports = function(context) {
     } else if (context.distro == "opensuse") {
       opensuse_install();
     } else {
-      if (context.distro == "debian" && context.version == 8) {
-          context.jessie = true;
-      }
       auto_install();
     }
 

--- a/_scripts/instruction-widget/templates/install/commonauto.html
+++ b/_scripts/instruction-widget/templates/install/commonauto.html
@@ -1,19 +1,3 @@
-{{#jessie}}
-<li>
-    Remove packaged Certbot installation
-    <p>
-    We previously recommended that Debian 8 (jessie) users install Certbot from
-    the packaged version. Because of important updates in the Certbot code,
-    we are now recommending that Debian 8 users switch to the
-    <tt>certbot-auto</tt> method, described below.<br>
-    Run this command on the command line on the machine to remove previous
-    installations of Certbot. If Certbot has never been installed, the command
-    will not do anything.
-    <pre>sudo apt-get remove certbot</pre>
-    </p>
-</li>
-{{/jessie}}
-
 <li>
     Install Certbot
     <p>


### PR DESCRIPTION
Remove Debian 8 instructions #587

I'm struggling a bit with testing locally, running into "Dockerfile cannot be built #386" so I am checking in for a Travis build.