### PR TITLE
Adding snapd text to certain OS instructions

### DIFF
--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 <aside class="note">
   <div class="note-header">
     <h3>Important Note:</h3>

--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -1,4 +1,9 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
 
 <aside class="note">
   <div class="note-header">

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,4 +1,11 @@
+{{#packaged}}
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
+{{/packaged}}
 
 {{#deprecated_32bits}}
 <aside class="note">

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 {{#deprecated_32bits}}
 <aside class="note">
   <div class="note-header">

--- a/_scripts/instruction-widget/templates/install/commonauto.html
+++ b/_scripts/instruction-widget/templates/install/commonauto.html
@@ -1,4 +1,6 @@
 {{#jessie}}
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 <li>
     Remove packaged Certbot installation
     <p>

--- a/_scripts/instruction-widget/templates/install/commonauto.html
+++ b/_scripts/instruction-widget/templates/install/commonauto.html
@@ -1,6 +1,4 @@
 {{#jessie}}
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
-
 <li>
     Remove packaged Certbot installation
     <p>

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 {{> header}}
 
 {{>installcertbot}}

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -1,4 +1,11 @@
+{{^devuan}}
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
+{{/devuan}}
 
 {{> header}}
 

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 {{> header}}
 {{>installcertbot}}
 

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -1,4 +1,9 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
 
 {{> header}}
 {{>installcertbot}}

--- a/_scripts/instruction-widget/templates/install/opensuse.html
+++ b/_scripts/instruction-widget/templates/install/opensuse.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 {{> header}}
 {{> installcertbot}}
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/opensuse.html
+++ b/_scripts/instruction-widget/templates/install/opensuse.html
@@ -1,4 +1,9 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
 
 {{> header}}
 {{> installcertbot}}

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,3 +1,5 @@
+<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+
 {{> header}}
 
 <li>

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,4 +1,9 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Join our beta test!</h3>
+  </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+</aside>
 
 {{> header}}
 


### PR DESCRIPTION
closes #559 
I've added this text to templates for the OSs requested. I tried creating a template partial and adding it that way, the *better* way, but couldn't get it to work. I ended up added it to each relevant template, sorry for the lack of DRY code. 

Also, two OSs aren't included that should be, Debian(other) and Ubuntu(other). Their script generates from the commonauto.html template. I could include the text there, but then it would also show on some OSs that it isn't relevant to.

Here's how the text is appearing, except for Debian 8, where it appears above instruction 2.
![Screenshot from 2020-06-11 11-51-41](https://user-images.githubusercontent.com/852512/84428899-1f081680-abdc-11ea-93e1-7d12bf015dcc.png)
