### PR TITLE
Add gsfonts to fix Sphinx ImageMagick extension error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV LC_ALL C.UTF-8
 # need rsync for deploy script and texlive for building docs
 RUN apt-get install -y --no-install-recommends \
     imagemagick \
-    gsfonts-x11 \
+    gsfonts \
     latexmk \
     rsync \
     texlive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV LC_ALL C.UTF-8
 # need rsync for deploy script and texlive for building docs
 RUN apt-get install -y --no-install-recommends \
     imagemagick \
+    gsfonts-x11 \
     latexmk \
     rsync \
     texlive \


### PR DESCRIPTION
Fixes #386.

This correponds to the "Dockerfile cannot be built #386" error "convert-im6.q16: unable to read font `(null)' @ error/annotate.c/RenderFreetype/1362."  I'm able to run docker-compose up after making this change.