### PR TITLE
Don't show snap banner in advanced instructions

### DIFF
--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -1,9 +1,11 @@
+{{^advanced}}
 <aside class="note">
   <div class="note-header">
     <h3>Join our beta test!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
+{{/advanced}}
 
 <aside class="note">
   <div class="note-header">

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -1,3 +1,4 @@
+{{^advanced}}
 {{#packaged}}
 <aside class="note">
   <div class="note-header">
@@ -6,6 +7,7 @@
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/packaged}}
+{{/advanced}}
 
 <!-- The advanced instructions don't use certbot-auto, so this warning isn't needed there. -->
 {{^advanced}}

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -1,3 +1,4 @@
+{{^advanced}}
 {{^devuan}}
 <aside class="note">
   <div class="note-header">
@@ -6,6 +7,7 @@
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/devuan}}
+{{/advanced}}
 
 {{> header}}
 

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -1,9 +1,11 @@
+{{^advanced}}
 <aside class="note">
   <div class="note-header">
     <h3>Join our beta test!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
+{{/advanced}}
 
 {{> header}}
 {{>installcertbot}}

--- a/_scripts/instruction-widget/templates/install/opensuse.html
+++ b/_scripts/instruction-widget/templates/install/opensuse.html
@@ -1,9 +1,11 @@
+{{^advanced}}
 <aside class="note">
   <div class="note-header">
     <h3>Join our beta test!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
+{{/advanced}}
 
 {{> header}}
 {{> installcertbot}}

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,9 +1,11 @@
+{{^advanced}}
 <aside class="note">
   <div class="note-header">
     <h3>Join our beta test!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
+{{/advanced}}
 
 {{> header}}
 


### PR DESCRIPTION
We probably shouldn't point people towards the "snapd" instructions right now if they are trying to obtain a wildcard certificate because our snapd wildcard instructions just have people use Docker.