### PR TITLE
Add NederHost to hosting_providers.json.

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2398,5 +2398,15 @@
     "plan": "",
     "reviewed": "2020.06.23",
     "note": "Available for free on all web hostings Linux plans."
+  },
+  {
+    "name": "NederHost",
+    "link": "https://www.nederhost.nl",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "https://www.nederhost.nl/nieuwsarchief/2019",
+    "plan": "",
+    "reviewed": "2020.07.15",
+    "note": "All webhosting plans include Let's Encrypt. The website is in Dutch."
   }
 ]


### PR DESCRIPTION
NederHost enables HTTPS with Let's Encrypt for all websites by default (and forces redirect to HTTPS for new websites). The announcement is in Dutch; if a translation is required please let me know.