### PR TITLE
Make Travis instructions more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ Website for [EFF's Certbot](https://certbot.eff.org/) project. Uses Jekyll for s
 
 ## Development
 
+### Using Travis
+
+If you're developing directly on this repository rather than on a fork, it's probably easiest to let Travis build the site for you.
+
+All branches and pull requests and built and tested by Travis.
+
+For branches, the built assets are pushed to an analagous branch in [certbot/website-builds](https://github.com/certbot/website-builds). Built assets from PRs are not saved because Travis doesn't provide a mechanism to securely push to a Github repo after PRs across forks.
+
+To view the build of any branch, checkout that branch from certbot/website-builds and run nginx to serve the files using the nginx configuration file from this certbot/website repository.
+
+For example, commands to do this might looks like:
+```
+git clone https://github.com/certbot/website-builds.git
+cd website-builds
+git checkout <RELEVANT BRANCH>
+CERTBOT_WEBSITE_PATH=/path/to/your/local/certbot/website/repo
+docker run -p 8000:4000 --rm -v "$CERTBOT_WEBSITE_PATH/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -v $(pwd):/usr/share/nginx/html:ro -it nginx
+```
+After starting that command running, you can access the website in your browser at http://localhost:8000. To shut the server down, just hit ctrl+c in the terminal you ran the docker command.
+
+If you are on linux and your user is not a member of the docker group, you'll need to run the command with `sudo`.
+
 ### With Docker
 
 1. Clone this repo and cd into the project directory.
@@ -92,22 +114,3 @@ To run the tests:
 npm test
 ```
 (Files with known issues are ignored.)
-
-## Travis Builds
-All branches and pull requests and built and tested by Travis.
-
-For branches, the built assets are pushed to an analagous branch in [certbot/website-builds](https://github.com/certbot/website-builds). Built assets from PRs are not saved because Travis doesn't provide a mechanism to securely push to a Github repo after PRs across forks.
-
-To view the build of any branch, checkout that branch from certbot/website-builds and run nginx to serve the files using the nginx configuration file from this certbot/website repository.
-
-For example, commands to do this might looks like:
-```
-git clone https://github.com/certbot/website-builds.git
-cd website-builds
-git checkout <RELEVANT BRANCH>
-CERTBOT_WEBSITE_PATH=/path/to/your/local/certbot/website/repo
-docker run -p 8000:4000 --rm -v "$CERTBOT_WEBSITE_PATH/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -v $(pwd):/usr/share/nginx/html:ro -it nginx
-```
-After starting that command running, you can access the website in your browser at http://localhost:8000. To shut the server down, just hit ctrl+c in the terminal you ran the docker command.
-
-If you are on linux and your user is not a member of the docker group, you'll need to run the command with `sudo`.


### PR DESCRIPTION
This moves our Travis instructions first in our README as suggested by Erica since it's what we have found works the best.