### PR TITLE
Remove broken Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@ Website for [EFF's Certbot](https://certbot.eff.org/) project. Uses Jekyll for s
 
 ## Development
 
-### With Docker
-
-1. Clone this repo and cd into the project directory.
-2. Get the documentation submodule:
-  * `git submodule init`
-  * `git submodule update`
-3. `docker-compose up`
-
-Docker-compose serves the site with nginx to more closely mirror production.
-
-### Without Docker
-
 #### Install
 1. Install `ruby 2.0+`, `node 8.0+`, and `npm 2.0+`.
 2. `gem install jekyll` (requires v3.0 or higher)


### PR DESCRIPTION
I think we should remove the instructions until https://github.com/certbot/website/issues/621 is resolved.