### PR TITLE
The Certbot snap is stable

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -256,7 +256,7 @@ module.exports = function(context) {
     template = "snap";
     context.base_command = "certbot";
     context.cron_included = true;
-    context.install_command = "sudo snap install --beta --classic";
+    context.install_command = "sudo snap install --classic";
     context.package = "certbot";
   }
 

--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -1,7 +1,7 @@
 {{^advanced}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/arch.html
+++ b/_scripts/instruction-widget/templates/install/arch.html
@@ -3,7 +3,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/advanced}}
 

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -4,7 +4,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/packaged}}
 {{/advanced}}

--- a/_scripts/instruction-widget/templates/install/centos.html
+++ b/_scripts/instruction-widget/templates/install/centos.html
@@ -2,7 +2,7 @@
 {{#packaged}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -2,7 +2,7 @@
 {{^devuan}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/debian.html
+++ b/_scripts/instruction-widget/templates/install/debian.html
@@ -4,7 +4,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/devuan}}
 {{/advanced}}

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -1,7 +1,7 @@
 {{^advanced}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/fedora.html
+++ b/_scripts/instruction-widget/templates/install/fedora.html
@@ -3,7 +3,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/advanced}}
 

--- a/_scripts/instruction-widget/templates/install/opensuse.html
+++ b/_scripts/instruction-widget/templates/install/opensuse.html
@@ -1,7 +1,7 @@
 {{^advanced}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/opensuse.html
+++ b/_scripts/instruction-widget/templates/install/opensuse.html
@@ -3,7 +3,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/advanced}}
 

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -5,7 +5,7 @@
     <h3>Snap Support</h3>
   </div>
   <p>
-  Certbot snap support is currently in its beta phase and supports the x86_64, ARMv7, and ARMv8 architectures.
+  The Certbot snap supports the x86_64, ARMv7, and ARMv8 architectures.
   You can find instructions for installing Certbot without using snap by selecting your OS in the dropdown above.
   </p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -1,7 +1,7 @@
 {{^advanced}}
 <aside class="note">
   <div class="note-header">
-    <h3>Join our beta test!</h3>
+    <h3>Try the Certbot snap!</h3>
   </div>
 <p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>

--- a/_scripts/instruction-widget/templates/install/ubuntu.html
+++ b/_scripts/instruction-widget/templates/install/ubuntu.html
@@ -3,7 +3,7 @@
   <div class="note-header">
     <h3>Try the Certbot snap!</h3>
   </div>
-<p>If you would like to help test a new way to install Certbot that automatically renews your certificates and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
+<p>If you would like to install Certbot using an approach that automatically configures certificate renewal and stays up-to-date, please choose "snapd" in the system dropdown above.</p>
 </aside>
 {{/advanced}}
 


### PR DESCRIPTION
Part of https://github.com/certbot/certbot/issues/8140.

There will be merge conflicts here with https://github.com/certbot/website/pull/613. We should also make sure the documentation is clear that the DNS plugin snaps should not be considered stable yet. I'm happy to work on both of these if you prefer.

Here are screenshots of these changes:

![Screen Shot 2020-07-28 at 10 15 44 AM](https://user-images.githubusercontent.com/6504915/88698878-78a89f80-d0bb-11ea-8474-2b8d2e578c18.png)
![Screen Shot 2020-07-28 at 10 16 29 AM](https://user-images.githubusercontent.com/6504915/88698886-7ba39000-d0bb-11ea-857e-cfc628d20cd5.png)
