### PR TITLE
gulp: fix fs.writeFile call breaking Node 10+

### DIFF
--- a/_gulp/tasks/instructions.js
+++ b/_gulp/tasks/instructions.js
@@ -36,7 +36,7 @@ gulp.task('instructions', gulp.series('instructions:clean', (done) => {
       instructions.forEach(function(el) {
         var path = dir + '/' + el.os.id + '-' + el.server.id + '.md';
         var body = '---\n---\n' + el.instructions;
-        fs.writeFile(path, body);
+        fs.writeFile(path, body, function() {});
       });
       done();
     }


### PR DESCRIPTION
In Node 7.x, calling `fs.writeFile` without a callback was deprecated[1].
In currently supported versions of Node (noting that v8 used by this
project is EOL), this now raises a `TypeError` and prevents `gulp` from
succeeding.

This commit fixes `DEP0013` and allows the project to be build on Node
10+.

1\. DEP0013, https://github.com/nodejs/node/blob/master/doc/api/deprecations.md#dep0013-fs-asynchronous-function-without-callback