### PR TITLE
Switch our Ubuntu instructions to our snap instructions

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -31,14 +31,11 @@ module.exports = function(context) {
         context.distro == "sharedhost") {
         return '';
     }
-    else if (context.distro == "snap") {
+    else if (context.distro == "snap" || context.distro == "ubuntu" ) {
       snap_install();
     }
     else if (context.distro == "debian" && context.version > 8) {
       debian_install();
-    }
-    else if (context.distro == "ubuntu" && context.version >= 14.04){
-        ubuntu_install();
     }
     // @todo: Implement or complete these.
     // else if (context.distro == "python"){
@@ -142,6 +139,8 @@ module.exports = function(context) {
     }
   }
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   ubuntu_install = function() {
     template = "ubuntu";
 


### PR DESCRIPTION
The instructions for every Ubuntu distro is now identical to our snap instructions. Since Ubuntu has snapd preinstalled, I figured this was a good first step towards encouraging the Certbot snap.

I thought keeping the `ubuntu_install` code and related template around was easier than deleting them and then finding them again in the git history if needed, but I can delete it now if people prefer.