### PR TITLE
Switch to Python 3 and stop using certbot-auto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get install -y --no-install-recommends \
     gsfonts \
     latexmk \
     rsync \
+    sudo \
     texlive \
     texlive-latex-extra
 

--- a/_docs.sh
+++ b/_docs.sh
@@ -4,9 +4,9 @@ case "$1" in
   "depend" )
     cd _docs
     export CERTBOT_WEBSITE='True'
-    sudo apt update
-    sudo apt install python3-dev python3-venv gcc libaugeas0 libssl-dev \
-                     libffi-dev ca-certificates openssl -y
+    sudo apt-get update
+    sudo apt-get install python3-dev python3-venv gcc libaugeas0 libssl-dev \
+                         libffi-dev ca-certificates openssl -y
     ./tools/venv3.py
     ;;
   "install" )

--- a/_docs.sh
+++ b/_docs.sh
@@ -4,12 +4,14 @@ case "$1" in
   "depend" )
     cd _docs
     export CERTBOT_WEBSITE='True'
-    ./letsencrypt-auto-source/letsencrypt-auto --os-packages-only
-    python ./tools/venv.py
+    sudo apt update
+    sudo apt install python3-dev python3-venv gcc libaugeas0 libssl-dev \
+                     libffi-dev ca-certificates openssl -y
+    ./tools/venv3.py
     ;;
   "install" )
     cd _docs
-    source ./venv/bin/activate
+    source ./venv3/bin/activate
     pip install --upgrade git+https://github.com/EFForg/sphinx_rtd_theme.git
     cd certbot
     make -C docs clean html epub latex latexpdf > /dev/null


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8164 and https://github.com/certbot/website/issues/611.

The addition of `sudo` in the Dockerfile was needed because `certbot-auto` was previously handling calling `sudo` or not based on whether or not we were already root.

Both the Dockerfile and the website build with this change. The only change I could find is new warnings at build time when trying to document `certbot.compat.os`, however, the resulting files appear to be the same (probably except any differences between Python 2 and Python 3 stdlib `os`). I fixed the warnings in https://github.com/certbot/certbot/pull/8209.