### PR TITLE
Update to a supported version of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
+dist: focal
 node_js:
   - 8.12.0
 
 addons:
   apt:
     packages:
+      - gsfonts
       - imagemagick
       - latexmk
       - texlive


### PR DESCRIPTION
https://github.com/certbot/certbot/pull/8206 would have broken website build here because Travis was using Python 3.5.

This PR fixes things by updating Travis to use Ubuntu 20.04 instead of Ubuntu 16.04. I think this upgrade is less scary than it could be because we have node and ruby pinned to specific versions. I tested the built version of the site with this change and didn't notice any difference.

`gsfonts` is needed because without it we error out trying to build Certbot's docs which you can see at https://travis-ci.com/github/certbot/website/builds/179783766#L1085.

Another thing to note here is https://github.com/certbot/certbot/pull/8206 will break the Dockerfile in this repo, but I updated the first post at https://github.com/certbot/website/issues/621 to mention this and I don't think it's a big deal since we deleted our Docker instructions in https://github.com/certbot/website/pull/622.