### PR TITLE
Add a note to help snap users configure PATH under all shells and sudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 _site
 .jekyll-metadata
+.jekyll-cache
 .sass-cache
 node_modules
 _instructions/
+build
+watch

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -70,6 +70,7 @@ module.exports = function(context) {
     partials.header = require(TEMPLATE_PATH + "header.html");
     partials.installcertbot = require(TEMPLATE_PATH + "installcertbot.html");
     partials.installcertbotwildcard = require(TEMPLATE_PATH + "installcertbotwildcard.html");
+    partials.preparecertbotsnapcommand = require(TEMPLATE_PATH + "preparecertbotsnapcommand.html");
     partials.dnsplugins = require(TEMPLATE_PATH + "dnsplugins.html");
     partials.dnspluginssetup = require(TEMPLATE_PATH + "dnspluginssetup.html");
 

--- a/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
+++ b/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
@@ -2,7 +2,7 @@
   Prepare the Certbot command
   <p>
   Execute the following instruction on the command line on the machine to ensure
-  that <tt>certbot</tt> command can be run.
+  that the <tt>certbot</tt> command can be run.
   </p>
   <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
 </li>

--- a/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
+++ b/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
@@ -1,0 +1,8 @@
+<li>
+  Prepare the Certbot command
+  <p>
+  Execute the following instruction on the command line on the machine to ensure
+  that <tt>certbot</tt> command can be run.
+  </p>
+  <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
+</li>

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -35,6 +35,7 @@
 {{#advanced}}
 {{#dns_plugins}}
 {{>installcertbotwildcard}}
+{{>preparecertbotsnapcommand}}
 <li>
   Confirm plugin containment level
   <p>
@@ -53,11 +54,7 @@
 
 {{^advanced}}
 {{>installcertbot}}
-  <p>
-  Execute the following instruction on the command line on the machine to ensure
-  that the <tt>certbot</tt> command can be run.
-  </p>
-  <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
+{{>preparecertbotsnapcommand}}
 {{/advanced}}
 
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -53,6 +53,11 @@
 
 {{^advanced}}
 {{>installcertbot}}
+  <p>
+  Execute the following instruction on the command line on the machine to ensure
+  that <tt>certbot</tt> command can be run.
+  </p>
+  <pre>sudo ln -s /snap/bin/certbot /usr/sbin/certbot</pre>
 {{/advanced}}
 
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -55,7 +55,7 @@
 {{>installcertbot}}
   <p>
   Execute the following instruction on the command line on the machine to ensure
-  that <tt>certbot</tt> command can be run.
+  that the <tt>certbot</tt> command can be run.
   </p>
   <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
 {{/advanced}}

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -17,6 +17,25 @@
     <p class="centered">
     <a class="link-button" href='https://snapcraft.io/docs/installing-snapd/'>install snapd</a>
     </p>
+
+    <aside class="note">
+      <div class="note-header">
+        <h3>Configuring snapd on specific shells</h3>
+      </div>
+      <p>
+      On shells like <tt>zsh</tt> or <tt>fish</tt>, the folder <tt>/snap/bin</tt>, which contains the snaps installed on your system,
+      needs to be added to the <tt>PATH</tt> environment variable. You will need to execute one of the following command in your
+      shell to add it permanently.<br/>
+      </p>
+      <p>
+        For <tt>zsh</tt>:
+        <pre style="margin:0;">echo -n 'export PATH=$PATH:/snap/bin' >> ~/.zshrc && . ~/.zshrc</pre>
+      </p>
+      <p>
+        For <tt>fish</tt>:
+        <pre style="margin:0;">echo -n 'set -gx PATH $PATH /snap/bin' >> ~/.config/fish/config.fish && . ~/.config/fish/config.fish</pre>
+      </p>
+    </aside>
 </li>
 <li>
     Remove any Certbot OS packages

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -17,25 +17,6 @@
     <p class="centered">
     <a class="link-button" href='https://snapcraft.io/docs/installing-snapd/'>install snapd</a>
     </p>
-
-    <aside class="note">
-      <div class="note-header">
-        <h3>Configuring snapd on specific shells</h3>
-      </div>
-      <p>
-      On shells like <tt>zsh</tt> or <tt>fish</tt>, the folder <tt>/snap/bin</tt>, which contains the snaps installed on your system,
-      needs to be added to the <tt>PATH</tt> environment variable. You will need to execute one of the following command in your
-      shell to add it permanently.<br/>
-      </p>
-      <p>
-        For <tt>zsh</tt>:
-        <pre style="margin:0;">echo -n 'export PATH=$PATH:/snap/bin' >> ~/.zshrc && . ~/.zshrc</pre>
-      </p>
-      <p>
-        For <tt>fish</tt>:
-        <pre style="margin:0;">echo -n 'set -gx PATH $PATH /snap/bin' >> ~/.config/fish/config.fish && . ~/.config/fish/config.fish</pre>
-      </p>
-    </aside>
 </li>
 <li>
     Remove any Certbot OS packages

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -57,7 +57,7 @@
   Execute the following instruction on the command line on the machine to ensure
   that <tt>certbot</tt> command can be run.
   </p>
-  <pre>sudo ln -s /snap/bin/certbot /usr/sbin/certbot</pre>
+  <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
 {{/advanced}}
 
 {{> dnspluginssetup}}


### PR DESCRIPTION
This PR adds a note to help users who hit the issue described in certbot/certbot#8246, providing convenient shell commands to add `/snap/bin` to `PATH` with zsh and fish.

Ultimately this issue should be fixed on snapd side (see https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1640514) but it the mean time I hope this will help users who want to use the Certbot snap with other shells than bash.