### PR TITLE
Move instructions for Arch Linux, openSUSE, and other UNIX to snaps

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -171,9 +171,9 @@
           "version": "15.0"
         },
         {
-            "name": "Other UNIX",
+            "name": "Other Linux",
             "id": "pip",
-            "distro": "python",
+            "distro": "linux",
             "version": "0"
         },
         {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -25,13 +25,18 @@ module.exports = function(context) {
     context.dns_plugins = false;
     context.dns_package_prefix = "";
     context.python_name = "python";
+
+    // This is the list of distributions that should be shown our snap
+    // instructions.
+    snap_distros = ["snap", "ubuntu", "arch", "opensuse"];
+
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
     if (context.webserver == "plesk" || context.distro == "windows" ||
         context.distro == "sharedhost") {
         return '';
     }
-    else if (context.distro == "snap" || context.distro == "ubuntu" ) {
+    else if (snap_distros.includes(context.distro)) {
       snap_install();
     }
     else if (context.distro == "debian" && context.version > 8) {
@@ -47,9 +52,6 @@ module.exports = function(context) {
     else if ((context.distro == "opbsd")||(context.distro =="freebsd")){
       bsd_install();
     }
-    else if (context.distro == "arch"){
-      arch_install();
-    }
     else if (context.distro == "fedora"){
       fedora_install();
     }
@@ -60,10 +62,8 @@ module.exports = function(context) {
       macos_install();
     } else if (context.distro == "devuan" && context.version > 1) {
       debian_install();
-    } else if (context.distro == "opensuse") {
-      opensuse_install();
     } else {
-      auto_install();
+      snap_install();
     }
 
     partials.auto = require(TEMPLATE_PATH + "commonauto.html");
@@ -175,6 +175,8 @@ module.exports = function(context) {
     }
   }
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   arch_install = function() {
     template = "arch";
     context.package = "certbot";
@@ -238,6 +240,8 @@ module.exports = function(context) {
     context.install_command = "brew install";
   }
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   opensuse_install = function() {
     template = "opensuse";
     context.package = "certbot";
@@ -265,6 +269,8 @@ module.exports = function(context) {
     context.dns_package_prefix_noflag = "certbot-dns";
   }
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   auto_install = function() {
     template = "auto";
     context.base_command = "/usr/local/bin/certbot-auto";


### PR DESCRIPTION
This fixes https://github.com/certbot/certbot/issues/8291.

As described in that issue and the Google Doc linked there, I changed the "Other UNIX" instructions to "Other Linux". I kept the id as `pip` to avoid breaking links to those instructions. I manually tested this and all of the dropdown options we expect display the snap instructions.

I initially was blocking doing this on having (part of) https://github.com/certbot/certbot/issues/8280 resolved, but a new enough version of snapd is packaged for both Arch Linux and openSUSE and I think getting people testing these instructions is important since the current plan is to deprecate certbot-auto on these platforms in our next release. I wrote more about the timeline here at https://github.com/certbot/certbot/issues/8292 if you're interested.