### PR TITLE
Update snap instructions to ensure snapd is up to date

### DIFF
--- a/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
+++ b/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
@@ -1,4 +1,13 @@
 <li>
+  Ensure that your version of snapd is up to date
+  <p>
+  Execute the following instruction on the command line on the machine to ensure
+  that you have the latest version of <tt>snapd</tt>.
+  </p>
+  <pre>sudo snap install core; sudo snap refresh</pre>
+</li>
+
+<li>
   Prepare the Certbot command
   <p>
   Execute the following instruction on the command line on the machine to ensure

--- a/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
+++ b/_scripts/instruction-widget/templates/install/preparecertbotsnapcommand.html
@@ -1,13 +1,4 @@
 <li>
-  Ensure that your version of snapd is up to date
-  <p>
-  Execute the following instruction on the command line on the machine to ensure
-  that you have the latest version of <tt>snapd</tt>.
-  </p>
-  <pre>sudo snap install core; sudo snap refresh</pre>
-</li>
-
-<li>
   Prepare the Certbot command
   <p>
   Execute the following instruction on the command line on the machine to ensure

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -19,6 +19,14 @@
     </p>
 </li>
 <li>
+  Ensure that your version of snapd is up to date
+  <p>
+  Execute the following instruction on the command line on the machine to ensure
+  that you have the latest version of <tt>snapd</tt>.
+  </p>
+  <pre>sudo snap install core; sudo snap refresh</pre>
+</li>
+<li>
     Remove any Certbot OS packages
     <p>
     If you have any Certbot packages installed using an OS package manager like

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -24,7 +24,7 @@
   Execute the following instructions on the command line on the machine to ensure
   that you have the latest version of <tt>snapd</tt>.
   </p>
-  <pre>sudo snap install core; sudo snap refresh</pre>
+  <pre>sudo snap install core; sudo snap refresh core</pre>
 </li>
 <li>
     Remove any Certbot OS packages

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -21,7 +21,7 @@
 <li>
   Ensure that your version of snapd is up to date
   <p>
-  Execute the following instruction on the command line on the machine to ensure
+  Execute the following instructions on the command line on the machine to ensure
   that you have the latest version of <tt>snapd</tt>.
   </p>
   <pre>sudo snap install core; sudo snap refresh</pre>


### PR DESCRIPTION
Partial fix for #8280

Similarly with what #8313 directly instruct users in case of certbot snap failure, this PR adds the relevant upgrade command for `snapd` in the certbot installation instruction in snap mode.