### PR TITLE
Update Debian instructions to snaps

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -39,9 +39,6 @@ module.exports = function(context) {
     else if (snap_distros.includes(context.distro)) {
       snap_install();
     }
-    else if (context.distro == "debian" && context.version > 8) {
-      debian_install();
-    }
     // @todo: Implement or complete these.
     // else if (context.distro == "python"){
     //   return pip_install();

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
     // This is the list of distributions that should be shown our snap
     // instructions.
-    snap_distros = ["snap", "ubuntu", "arch", "opensuse", "fedora", "debian"];
+    var snap_distros = ["snap", "ubuntu", "arch", "opensuse", "fedora", "debian"];
 
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
     // This is the list of distributions that should be shown our snap
     // instructions.
-    snap_distros = ["snap", "ubuntu", "arch", "opensuse"];
+    snap_distros = ["snap", "ubuntu", "arch", "opensuse", "debian"];
 
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8293.

I tested this following the instructions at https://github.com/certbot/website#building-with-travis and confirmed that the Debian instructions now use the snaps while the Devuan instructions which cannot use snaps still have installation instructions using `apt-get`.