### PR TITLE
Instruct RHEL to use snaps when possible

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -52,9 +52,6 @@ module.exports = function(context) {
     else if ((context.distro == "opbsd")||(context.distro =="freebsd")){
       bsd_install();
     }
-    else if (context.distro == "fedora"){
-      fedora_install();
-    }
     else if (context.distro == "centos" || context.distro == "rhel") {
       // The oldest version of RHEL where snapd is packaged is RHEL 7.
       if (context.version < 7) {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
     // This is the list of distributions that should be shown our snap
     // instructions.
-    snap_distros = ["snap", "ubuntu", "arch", "opensuse"];
+    snap_distros = ["snap", "ubuntu", "arch", "opensuse", "fedora"];
 
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
@@ -56,7 +56,12 @@ module.exports = function(context) {
       fedora_install();
     }
     else if (context.distro == "centos" || context.distro == "rhel") {
-      centos_install();
+      // The oldest version of RHEL where snapd is packaged is RHEL 7.
+      if (context.version < 7) {
+        centos_install();
+      } else {
+        snap_install();
+      }
     }
     else if (context.distro == "macos") {
       macos_install();
@@ -194,6 +199,8 @@ module.exports = function(context) {
     context.dns_package_prefix = "certbot-dns";
   }
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   fedora_install = function() {
     template = "fedora";
     context.package = "certbot";


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8295 with the exception of removing instructions for CentOS/RHEL 6. If this PR is merged, I will create an issue to track that piece.

In my initial plan at https://docs.google.com/document/d/174ILmAfVlqWvYH9n8gkQnLc-FECiIsKpa2nZCxEklik/edit?usp=sharing, I suggested waiting to do this, but I think we may as well do this now. It should help our snaps be more widely tested before we deprecate certbot-auto on the platform and if something goes wrong, we can always revert this PR.

I tested this following the instructions at https://github.com/certbot/website#building-with-travis and confirmed that the CentOS/RHEL 7+ and Fedora instructions now use the snaps while the CentOS/RHEL 6 instructions still direct people to `certbot-auto`.