### PR TITLE
Remove snap connect instruction as it's no longer needed

### DIFF
--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -67,18 +67,3 @@
 
 {{> dnspluginssetup}}
 
-{{#advanced}}
-{{#dns_plugins}}
-<li>
-  Connect the DNS plugin snap to the Certbot snap
-  <p>
-    Run the following command, replacing &lt;PLUGIN&gt; with the name of your DNS provider.
-  </p>
-  <pre>sudo snap connect certbot:plugin {{dns_package_prefix_noflag}}-&lt;PLUGIN&gt;</pre>
-  <p>
-    For example, if your DNS provider is Cloudflare, you'd run the following command:
-  </p>
-  <pre>sudo snap connect certbot:plugin {{dns_package_prefix_noflag}}-cloudflare</pre>
-</li>
-{{/dns_plugins}}
-{{/advanced}}


### PR DESCRIPTION
Fixes #664.

Here's how it looks after the changes:
![Screenshot from 2020-10-22 12-23-09](https://user-images.githubusercontent.com/1227205/96919950-6394a000-1461-11eb-9403-7d8bc8c8767b.png)
