### PR TITLE
Remove links to ssllabs from instructions

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -71,10 +71,5 @@
   <p>
   To confirm that your site is set up properly, visit <tt>https://yourwebsite.com/</tt> in your browser and
   look for the lock icon in the URL bar.
-  If you want to check that you have the top-of-the-line installation, you can head to
-  <a href='https://www.ssllabs.com/ssltest/'>https://www.ssllabs.com/ssltest/</a>.
-  </p>
-  <p class="centered">
-  <a class="link-button" href='https://www.ssllabs.com/ssltest/'>check your site's <img src="/images/Lock.svg"> https:// at SSL Labs</a>.
   </p>
 </li>

--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -103,11 +103,6 @@ able to use to obtain a certificate from Let's Encrypt.
   <p>
   To confirm that your site is set up properly, visit <tt>https://yourwebsite.com/</tt> in your browser and
   look for the lock icon in the URL bar.
-  If you want to check that you have the top-of-the-line installation, you can head to
-  <a href='https://www.ssllabs.com/ssltest/'>https://www.ssllabs.com/ssltest/</a>.
-  </p>
-  <p class="centered">
-  <a class="link-button" href='https://www.ssllabs.com/ssltest/'>check your site's <img src="/images/Lock.svg" /> https:// at SSL Labs</a>.
   </p>
 </li>
 <li>Note for Windows Apache or Nginx users


### PR DESCRIPTION
In https://github.com/certbot/certbot/pull/8109 based on the behavior described at https://github.com/certbot/certbot/issues/7728 and our user testing, we removed SSL Labs from Certbot's output. This PR does the same thing to our website instructions.

I left the links under `_faq_entries/18-debugging-tools.md` and `_includes/help/learn_more.html` which talk about it as a tool to use in the context of debugging why your TLS config doesn't work. I think in that context, it is still very helpful.

Screenshots of the relevant part of the new instructions are:
## Non-Windows
![Screen Shot 2020-11-11 at 3 00 11 PM](https://user-images.githubusercontent.com/6504915/98874253-bf35c600-242e-11eb-9e92-b97da70c7487.png)
## Windows
![Screen Shot 2020-11-11 at 3 00 43 PM](https://user-images.githubusercontent.com/6504915/98874257-c0ff8980-242e-11eb-94d5-fe2483a4ba47.png)

