### PR TITLE
Add MightWeb

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1169,6 +1169,16 @@
     "reviewed": "2020.3.3",
     "note": "Site and link are in German"
   },
+   {
+    "name": "MightWeb",
+    "link": "",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2020.11.14",
+    "note": ""
+  },
   {
     "name": "mijn.host",
     "link": "https://mijn.host/",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1171,7 +1171,7 @@
   },
   {
     "name": "MightWeb",
-    "link": "",
+    "link": "https://mightweb.net/",
     "category": "full",
     "tutorial": "",
     "announcement": "",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1169,7 +1169,7 @@
     "reviewed": "2020.3.3",
     "note": "Site and link are in German"
   },
-   {
+  {
     "name": "MightWeb",
     "link": "",
     "category": "full",


### PR DESCRIPTION
Mightweb supports Let'sEncrypt on all [shared](https://mightweb.net/web-hosting/) and [reseller](https://mightweb.net/reseller-hosting/) plans.