### PR TITLE
Add netclusive to hosting providers

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -137,7 +137,7 @@
     "announcement": "",
     "plan": "",
     "reviewed": "2020.10.01",
-    "note": "The website is in german. Old plans of shared web hosting with confixx panel have full HTTPS support. New plans of shared web hosting with Plesk panel also have full HTTPS support."
+    "note": "The website is in German."
   },
   {
     "name": "Netlify",


### PR DESCRIPTION
Improved pull request based on information from previous PR certbot#654
Plesk now requests a certificate while the account is created. Exception handling (f. exp. existing domains not already transferred) is described in the tutorial link in german.