### PR TITLE
Remove instructions for CentOS 6 and RHEL 6

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -99,18 +99,6 @@
             "version": "0"
         },
         {
-            "name": "CentOS 6",
-            "id": "centos6",
-            "distro": "centos",
-            "version": "6"
-        },
-        {
-            "name": "RHEL 6",
-            "id": "centosrhel6",
-            "distro": "rhel",
-            "version": "6"
-        },
-        {
             "name": "CentOS/RHEL 7",
             "id": "centosrhel7",
             "distro": "centos",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
     // This is the list of distributions that should be shown our snap
     // instructions.
-    var snap_distros = ["snap", "ubuntu", "arch", "opensuse", "fedora", "debian"];
+    var snap_distros = ["snap", "ubuntu", "arch", "opensuse", "fedora", "debian", "centos", "rhel"];
 
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
@@ -48,14 +48,6 @@ module.exports = function(context) {
     }
     else if ((context.distro == "opbsd")||(context.distro =="freebsd")){
       bsd_install();
-    }
-    else if (context.distro == "centos" || context.distro == "rhel") {
-      // The oldest version of RHEL where snapd is packaged is RHEL 7.
-      if (context.version < 7) {
-        centos_install();
-      } else {
-        snap_install();
-      }
     }
     else if (context.distro == "macos") {
       macos_install();
@@ -82,6 +74,8 @@ module.exports = function(context) {
    * context and partials associated with that template.
    */
 
+  // This function is currently unused, but we keep it around to make it easy
+  // to generate these instructions again if we want to.
   centos_install = function() {
     template = "centos";
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8358

I followed the same approach than for previous instructions removals, by editing the minimal set of logic required to reach the target, but keeping existing methods and templates.

I think we should make a real clean of the website codebase eventually. If you agree, I can make a PR for it.