### PR TITLE
Fix docker build by changing base image to python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,7 +24,6 @@ _docs
 !_docs/letsencrypt-auto-source
 
 # ignore build artifacts
-package-lock.json
 node_modules
 _site
 _instructions

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,3 +21,4 @@ _site
 _instructions
 .sass-cache
 .jekyll-*
+_docs/venv*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# ignore docker config
+docker-compose.yml
+Dockerfile
+.dockerignore
+nginx.conf
+
+# ignore repo docs
+EDITING.md
+README.md
+LICENSE.txt
+.git*
+
+# ignore secrets / CI logic
+build_key.enc
+push-build.sh
+.travis.yml
+
+# ignore unnecessary certbot files
+_docs
+!_docs/tools
+!_docs/acme
+!_docs/certbot
+!_docs/certbot-*
+!_docs/letsencrypt-auto-source
+
+# ignore build artifacts
+node_modules
+_site
+_instructions
+.sass-cache
+.jekyll-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@ _docs
 !_docs/letsencrypt-auto-source
 
 # ignore build artifacts
+package-lock.json
 node_modules
 _site
 _instructions

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,14 +15,6 @@ build_key.enc
 push-build.sh
 .travis.yml
 
-# ignore unnecessary certbot files
-_docs
-!_docs/tools
-!_docs/acme
-!_docs/certbot
-!_docs/certbot-*
-!_docs/letsencrypt-auto-source
-
 # ignore build artifacts
 node_modules
 _site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM python:3.6
 
 RUN mkdir /opt/certbot
 WORKDIR /opt/certbot
@@ -29,11 +29,18 @@ RUN apt-get install -y --no-install-recommends \
     texlive-latex-extra
 
 # Install ruby and dependencies
-RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc &&\
-    mkdir /src && cd /src && git clone https://github.com/sstephenson/ruby-build.git &&\
-    cd /src/ruby-build && ./install.sh &&\
-    cd / && rm -rf /src/ruby-build && ruby-build $RUBY_VERSION /usr/local
-RUN gem install jekyll html-proofer
+RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc && \
+    mkdir /src && cd /src && git clone https://github.com/sstephenson/ruby-build.git && \
+    cd /src/ruby-build && ./install.sh && \
+    cd / && rm -rf /src/ruby-build && ruby-build $RUBY_VERSION /usr/local && \
+    gem install jekyll html-proofer && \
+
+    # Install node and dependencies
+    apt-get install -y npm && npm install gulp-cli -g
+
+# Install Javascript packages
+COPY package.json package-lock.json ./
+RUN npm install
 
 # Install docs dependencies
 COPY _docs/ ./_docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,13 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL C.UTF-8
 
+# Configure locales. Install rsync for deploy script, texlive for building docs.
 RUN apt-get update && apt-get install locales -y && \
     echo dpkg-reconfigure -f noninteractive tzdata && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8 && \
-
-    # Install rsync for deploy script, texlive for building docs
     apt-get install -y --no-install-recommends \
     imagemagick \
     gsfonts \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,13 +34,16 @@ RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc && \
     mkdir /src && cd /src && git clone https://github.com/sstephenson/ruby-build.git && \
     cd /src/ruby-build && ./install.sh && \
     cd / && rm -rf /src/ruby-build && ruby-build $RUBY_VERSION /usr/local && \
-    gem install jekyll html-proofer && \
+    gem install jekyll html-proofer
 
-    # Install node and dependencies
-    apt-get install -y npm && npm install gulp-cli -g
+# Install node and dependencies
+RUN apt-get install -y npm
+RUN npm install -g n
+RUN n lts
+RUN npm install -g npm gulp-cli
 
 # Install Javascript packages
-COPY package.json package-lock.json ./
+COPY package.json ./
 RUN npm install
 
 # Install docs dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY . .
 
 RUN gulp build
 
-CMD ["gulp", "jekyll:watch"]
+CMD ["gulp", "--series", "instructions", "jekyll:watch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ RUN npm install
 # Install docs dependencies
 COPY _docs.sh ./
 COPY _docs/ ./_docs/
-COPY _docs/tools ./_docs/tools
-COPY _docs/letsencrypt-auto-source ./_docs/letsencrypt-auto-source
 RUN ./_docs.sh depend
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,19 @@ ENV RUBY_VERSION 2.6.3
 ENV NOKOGIRI_USE_SYSTEM_LIBRARIES true
 
 # Set UTF-8 character encoding
-RUN apt-get update && apt-get install locales -y
-RUN echo dpkg-reconfigure -f noninteractive tzdata && \
-    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
-    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
-    dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL C.UTF-8
 
-# need rsync for deploy script and texlive for building docs
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install locales -y && \
+    echo dpkg-reconfigure -f noninteractive tzdata && \
+    sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8 && \
+
+    # Install rsync for deploy script, texlive for building docs
+    apt-get install -y --no-install-recommends \
     imagemagick \
     gsfonts \
     latexmk \
@@ -43,35 +44,13 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 # Install docs dependencies
-COPY _docs/ ./_docs
 COPY _docs.sh ./
+COPY _docs/ ./_docs/
+COPY _docs/tools ./_docs/tools
+COPY _docs/letsencrypt-auto-source ./_docs/letsencrypt-auto-source
 RUN ./_docs.sh depend
 
-# Install js dependencies
-COPY package.json ./
-RUN npm install gulp-cli -g
-RUN npm install
-
-COPY _data ./_data
-COPY _faq_entries ./_faq_entries
-COPY _gulp ./_gulp
-COPY _includes ./_includes
-COPY _layouts ./_layouts
-COPY _sass ./_sass
-COPY _scripts ./_scripts
-COPY about ./about
-COPY faq ./faq
-COPY fonts ./fonts
-COPY images ./images
-COPY privacy ./privacy
-COPY support ./support
-COPY _config.yml ./_config.yml
-COPY favicon.ico ./favicon.ico
-COPY gulpfile.js ./gulpfile.js
-COPY index.html ./index.html
-COPY certbot-deploy ./certbot-deploy
-COPY .git ./.git
-COPY .gitmodules ./.gitmodules
+COPY . .
 
 RUN gulp build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,4 +55,4 @@ COPY . .
 
 RUN gulp build
 
-CMD ["gulp", "--series", "instructions", "jekyll:watch"]
+CMD ["gulp", "jekyll:watch"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,12 @@ RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc && \
 # Install node and dependencies
 RUN apt-get install -y npm
 RUN npm install -g n
-RUN n lts
+RUN n 8.12.0
 RUN npm install -g npm gulp-cli
 
 # Install Javascript packages
 COPY package.json ./
+COPY package-lock.json ./
 RUN npm install
 
 # Install docs dependencies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are on linux and your user is not a member of the docker group, you'll ne
   * `git submodule update`
 3. `docker-compose up`
 
-docker-compose serves the site with nginx to more closely mirror production.
+docker-compose serves the site with nginx to more closely mirror production. Any changes you make to your local files while the site is running will automatically be picked up and you can access the website in your browser at http://localhost:4000.
 
 
 ### Building locally without Docker

--- a/README.md
+++ b/README.md
@@ -28,7 +28,18 @@ After starting that command running, you can access the website in your browser 
 
 If you are on linux and your user is not a member of the docker group, you'll need to run the command with `sudo`.
 
-### Building locally
+### Building locally with Docker
+
+1. Clone this repo and cd into the project directory.
+2. Get the documentation submodule:
+  * `git submodule init`
+  * `git submodule update`
+3. `docker-compose up`
+
+docker-compose serves the site with nginx to more closely mirror production.
+
+
+### Building locally without Docker
 
 #### Install
 1. Install `ruby 2.0+`, `node 8.0+`, and `npm 2.0+`.

--- a/_gulp/index.js
+++ b/_gulp/index.js
@@ -7,10 +7,7 @@ tasks.forEach(function(task) {
 });
 
 gulp.task('watch',
-  gulp.parallel('instructions', 'css', 'js', 'jekyll:watch', 'serve'));
+  gulp.parallel('css', 'js', 'jekyll:watch', 'serve'));
 
 gulp.task('build',
-  gulp.series('instructions',
-    gulp.parallel('css', 'js', 'docs:install', 'jekyll:build')
-  )
-);
+  gulp.parallel('css', 'js', 'docs:install', 'jekyll:build'));

--- a/_plugins/instructions.rb
+++ b/_plugins/instructions.rb
@@ -11,12 +11,12 @@ module Jekyll
       end
 
       def certbot_instructions_watch(options, site=nil)
-        path = "_data/"
+        paths = %w(_data/ _scripts/instruction-widget)
         opts = { force_polling: options["force_polling"] }
 
-        listener = Listen.to(path, opts) do |m, a, _|
+        listener = Listen.to(*paths, opts) do |m, a, _|
           (m + a).each do |path|
-            if File.basename(path) == "inputs.json"
+            if path =~ %r{/inputs.json|/_scripts/instruction-widget/}
               system("gulp", "instructions")
             end
           end

--- a/_plugins/instructions.rb
+++ b/_plugins/instructions.rb
@@ -1,0 +1,35 @@
+require "jekyll-watch"
+
+module Jekyll
+  module Watcher
+    class << self
+      alias jekyll_watch watch
+
+      def watch(*args)
+        certbot_instructions_watch(*args)
+        jekyll_watch(*args)
+      end
+
+      def certbot_instructions_watch(options, site=nil)
+        path = "_data/"
+        opts = { force_polling: options["force_polling"] }
+
+        listener = Listen.to(path, opts) do |m, a, _|
+          (m + a).each do |path|
+            if File.basename(path) == "inputs.json"
+              system("gulp", "instructions")
+            end
+          end
+        end
+
+        listener.start
+
+        trap("INT") { listener.stop }
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register :site, :after_init do
+  system("gulp", "instructions")
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,13 @@ services:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     links:
       - site
+
   site:
     build: .
     volumes:
       - .:/opt/certbot/
       - /opt/certbot/node_modules
-      - /opt/certbot/instructions
+      - /opt/certbot/_instructions
       - /opt/certbot/_docs
       - assets:/opt/certbot/_site
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1197,9 +1197,9 @@
       }
     },
     "datatables.net": {
-      "version": "1.10.19",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
-      "integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
+      "version": "1.10.22",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.22.tgz",
+      "integrity": "sha512-ujn8GvkQIBYzYH54XY7OrI0Zb35TKRd9ABYfbnXgBfwTGIFT6UsmXrfHU5Yk+MSDoF0sDu2TB+31V6c+zUZ0Pw==",
       "requires": {
         "jquery": ">=1.7"
       }
@@ -1211,6 +1211,16 @@
       "requires": {
         "datatables.net": "1.10.19",
         "jquery": ">=1.7"
+      },
+      "dependencies": {
+        "datatables.net": {
+          "version": "1.10.19",
+          "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
+          "integrity": "sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==",
+          "requires": {
+            "jquery": ">=1.7"
+          }
+        }
       }
     },
     "date-now": {


### PR DESCRIPTION
This branch fixes the docker build by switching the base image to python:3.6. Node is fetched using apt to make up for this, and I've also made some improvements to build time by reducing intermediate layers and limiting the build context in .dockerignore.