### PR TITLE
Update out-of-date note

### DIFF
--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -6,7 +6,7 @@
   The Certbot snap supports the x86_64, ARMv7, and ARMv8 architectures.
   While we strongly recommend that most users install Certbot through the snap,
   you can find alternate installation instructions
-  <a href="/docs/install.html">here</a>
+  <a href="/docs/install.html">here</a>.
   </p>
 </aside>
 {{> header}}

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -4,7 +4,9 @@
   </div>
   <p>
   The Certbot snap supports the x86_64, ARMv7, and ARMv8 architectures.
-  You can find instructions for installing Certbot without using snap by selecting your OS in the dropdown above.
+  While we strongly recommend that most users install Certbot through the snap,
+  you can find alternate installation instructions
+  <a href="/docs/install.html">here</a>
   </p>
 </aside>
 {{> header}}


### PR DESCRIPTION
We say they can find non-snap instructions through the dropdown menu, but that's not true anymore.

I tested this PR locally and the link works as expected.