### PR TITLE
ignore twitter URLs during link check

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gulp build certbot.",
   "scripts": {
-    "test": "htmlproofer ./_site --checks-to-ignore LinkCheck --empty-alt-ignore true --file-ignore ./_site/docs/search.html && htmlproofer ./_site --checks-to-ignore ImageCheck,ScriptCheck --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true"
+    "test": "htmlproofer ./_site --checks-to-ignore LinkCheck --empty-alt-ignore true --file-ignore ./_site/docs/search.html && htmlproofer ./_site --checks-to-ignore ImageCheck,ScriptCheck --only-4xx true --file-ignore /_site/docs/_modules/,./_site/docs/api/display.html,./_site/docs/contributing.html,./_site/docs/genindex.html,./_site/docs/intro.html,./_site/docs/py-modindex.html,./_site/docs/api/log.html,./_site/hosting_providers/index.html --allow-hash-href true --url-ignore '/twitter.com/'"
   },
   "dependencies": {
     "browser-sync": "^2.19.0",


### PR DESCRIPTION
This was done because Twitter was returning 400s saying that our browser
wasn't supported.