### PR TITLE
Add certbot-auto uninstall instructions

### DIFF
--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -29,7 +29,7 @@
   <pre>sudo snap install core; sudo snap refresh core</pre>
 </li>
 <li>
-    Remove any Certbot OS packages
+    Remove certbot-auto and any Certbot OS packages
     <p>
     If you have any Certbot packages installed using an OS package manager like
     <tt>apt</tt>, <tt>dnf</tt>, or <tt>yum</tt>, you should remove them before
@@ -38,6 +38,11 @@
     package manager. The exact command to do this depends on your OS, but
     common examples are <tt>sudo apt-get remove certbot</tt>, <tt>sudo dnf
     remove certbot</tt>, or <tt>sudo yum remove certbot</tt>.
+    </p>
+    <p>
+    If you previously used Certbot through the certbot-auto script, you should
+    also remove its installation by following the instructions <a
+    href="/docs/uninstall.html">here</a>.
     </p>
 </li>
 


### PR DESCRIPTION
Fixes https://github.com/certbot/certbot/issues/8545

Diff of docs is:
```
diff --git a/certbot/docs/install.rst b/certbot/docs/install.rst
index df32bb60e..aefe1809e 100644
--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -243,6 +243,8 @@ Certbot-Auto
 
 We used to have a shell script named ``certbot-auto`` to help people install
 Certbot on UNIX operating systems, however, this script is no longer supported.
+If you want to uninstall ``certbot-auto``, you can follow our instructions
+:doc:`here <uninstall>`.
 
 Problems with Python virtual environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
diff --git a/certbot/docs/uninstall.rst b/certbot/docs/uninstall.rst
new file mode 100644
index 000000000..65151242c
--- /dev/null
+++ b/certbot/docs/uninstall.rst
@@ -0,0 +1,16 @@
+=========================
+Uninstalling certbot-auto
+=========================
+
+To uninstall ``certbot-auto``, you need to do three things:
+
+1. If you added a cron job or systemd timer to automatically run
+   ``certbot-auto`` to renew your certificates, you should delete it. If you
+   did this by following our instructions, you can delete the entry added to
+   ``/etc/crontab`` by running a command like ``sudo sed -i '/certbot-auto/d'
+   /etc/crontab``.
+2. Delete the ``certbot-auto`` script. If you placed it in ``/usr/local/bin``
+   like we recommended, you can delete it by running ``sudo rm
+   /usr/local/bin/certbot-auto``.
+3. Delete the Certbot installation created by ``certbot-auto`` by running
+   ``sudo rm -rf /opt/eff.org``.
```
A screenshot of the changes to our snap instructions is:
![Screen Shot 2020-12-21 at 11 25 15 AM](https://user-images.githubusercontent.com/6504915/102814323-3db34b00-437f-11eb-9a48-3ecdc321fb42.png)
The link shown there works.