### PR TITLE
Add convenience script for reviewing branches from website-builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,17 @@ Website for [EFF's Certbot](https://certbot.eff.org/) project. Uses Jekyll for s
 
 If you're developing directly on this repository rather than on a fork, it's probably easiest to let Travis build the site for you.
 
-All branches and pull requests and built and tested by Travis.
+All branches and pull requests are built and tested by Travis.
 
 For branches, the built assets are pushed to an analagous branch in [certbot/website-builds](https://github.com/certbot/website-builds). Built assets from PRs are not saved because Travis doesn't provide a mechanism to securely push to a Github repo after PRs across forks.
 
-To view the build of any branch, checkout that branch from certbot/website-builds and run nginx to serve the files using the nginx configuration file from this certbot/website repository.
+To view the build of any branch, use the `website-builds.sh`, which will fetch the branch from certbot/website-builds and start a docker to serve the files.
 
-For example, commands to do this might looks like:
 ```
-git clone https://github.com/certbot/website-builds.git
-cd website-builds
-git checkout <RELEVANT BRANCH>
-CERTBOT_WEBSITE_PATH=/path/to/your/local/certbot/website/repo
-docker run -p 8000:4000 --rm -v "$CERTBOT_WEBSITE_PATH/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -v $(pwd):/usr/share/nginx/html:ro -it nginx
+./website-builds.sh <NAME OF BRANCH>
 ```
-After starting that command running, you can access the website in your browser at http://localhost:8000. To shut the server down, just hit ctrl+c in the terminal you ran the docker command.
+
+After starting that command, you can access the website in your browser at http://localhost:8000. To shut the server down, just hit Ctrl+C in the terminal where `website-builds.sh` is running.
 
 If you are on linux and your user is not a member of the docker group, you'll need to run the command with `sudo`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All branches and pull requests are built and tested by Travis.
 
 For branches, the built assets are pushed to an analagous branch in [certbot/website-builds](https://github.com/certbot/website-builds). Built assets from PRs are not saved because Travis doesn't provide a mechanism to securely push to a Github repo after PRs across forks.
 
-To view the build of any branch, use the `website-builds.sh`, which will fetch the branch from certbot/website-builds and start a docker to serve the files.
+To view the build of any branch, use the script `website-builds.sh`, which will fetch the branch from certbot/website-builds and start a docker to serve the files.
 
 ```
 ./website-builds.sh <NAME OF BRANCH>

--- a/website-builds.sh
+++ b/website-builds.sh
@@ -25,6 +25,7 @@ RUN cd /usr/share/nginx \
 EOF
 
 echo
-echo "Starting server. You can access the website in your browser at http://localhost:8000. Press Ctrl-C to shut down."
+echo "Starting server. You can access the website in your browser at http://localhost:8000."
+echo -e "\033[1;33mPress Ctrl-C to shut down.\033[0m"
 
 docker run --rm -p 8000:4000 -v "$(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -it "$TAG"

--- a/website-builds.sh
+++ b/website-builds.sh
@@ -18,6 +18,8 @@ set -e
 docker build --no-cache -t "$TAG" -<<EOF
 FROM nginx:alpine
 
+ENV NGINX_ENTRYPOINT_QUIET_LOGS 0
+
 RUN cd /usr/share/nginx \
  && wget "https://github.com/certbot/website-builds/archive/$REF.zip" \
  && unzip *.zip \

--- a/website-builds.sh
+++ b/website-builds.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-set -e
-
 REF="$1"
 TAG="website-builds:$REF"
 
 if [ -z "$REF" ]; then
-    echo "Usage: $0 ref"
+    echo >&2 "Usage: $0 ref"
+    exit 1
 fi
+
+if ! which docker >/dev/null 2>&1; then
+   echo >&2 "Docker is required to run this script."
+   echo >&2 "https://docs.docker.com/get-docker/"
+   exit 1
+fi
+set -e
 
 docker build --no-cache -t "$TAG" -<<EOF
 FROM nginx:alpine

--- a/website-builds.sh
+++ b/website-builds.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+REF="$1"
+TAG="website-builds:$REF"
+
+if [ -z "$REF" ]; then
+    echo "Usage: $0 ref"
+fi
+
+docker build --no-cache -t "$TAG" -<<EOF
+FROM nginx:alpine
+
+RUN cd /usr/share/nginx \
+ && wget "https://github.com/certbot/website-builds/archive/$REF.zip" \
+ && unzip *.zip \
+ && mv website-builds-*/* html
+EOF
+
+echo
+echo "Starting server. You can access the website in your browser at http://localhost:8000. Press Ctrl-C to shut down."
+
+docker run --rm -p 8000:4000 -v "$(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro" -it "$TAG"


### PR DESCRIPTION
Fixes #579. This adds a script `website-builds.sh` that takes a branch name as an argument, fetches the build of that branch from certbot/website-builds, and wraps it in an nginx docker container with nginx.conf.