### PR TITLE
Enable DNS plugin instructions for Gentoo

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -165,6 +165,8 @@ module.exports = function(context) {
     } else if (context.webserver == "nginx") {
       context.package += " app-crypt/certbot-nginx";
     }
+    context.dns_plugins = true;
+    context.dns_package_prefix = "app-crypt/certbot-dns";
   }
 
   // This function is currently unused, but we keep it around to make it easy

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -25,7 +25,7 @@
     <p>
         If not installed already, install <a href="https://packages.gentoo.org/packages/app-eselect/eselect-repository">app-eselect/eselect-repository</a>:
     </p>
-    <pre>sudo emerge -av app-eselect/eselect-repository</pre>
+    <pre>sudo emerge -av app-eselect/eselect-repository dev-vcs/git</pre>
     <p>
         Next, enable the overlay and sync it:
     </p>

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -4,7 +4,7 @@
         <h3>Experimental</h3>
     </div>
     <p>
-        Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay, which is maintained by a member of the Community voluntarily, are <strong>experimental</strong> and is not officially supported by Gentoo, Let's Encrypt nor EFF.
+        Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay, which is maintained by a member of the Community voluntarily, are <strong>experimental</strong> and are not officially supported by Gentoo, Let's Encrypt nor EFF.
     </p>
     <div class="note-header">
     <h3>Bug reporting</h3>

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -1,3 +1,44 @@
+{{#advanced}}
+<aside class="note">
+    <div class="note-header">
+        <h3>Experimental</h3>
+    </div>
+    <p>
+        Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay are <strong>experimental</strong> and is not officially supported by Gentoo, Let's Encrypt nor EFF.
+    </p>
+</aside>
+<li>
+    Enable the `certbot-dns-plugins` overlay
+    <p>
+        If you require any other DNS plugin other than the <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a> plugin, you will need the required ebuilds to install them. An <a href="https://wiki.gentoo.org/wiki/Ebuild_repository">overlay</a> called <a href="https://github.com/gentoo-mirror/certbot-dns-plugins">certbot-dns-plugins</a> exists with all other certbot DNS plugins. To be able to use those ebuilds, you will need to add the aformentioned overlay.
+    </p>
+    <h3>Using `eselect`</h3>
+    <p>
+        If not installed already, install <a href="https://packages.gentoo.org/packages/app-eselect/eselect-repository">app-eselect/eselect-repository</a>:
+    </p>
+    <pre>sudo emerge -av app-eselect/eselect-repository</pre>
+    <p>
+        Next, enable the overlay and sync it:
+    </p>
+      <pre class="no-before"><ol><li>sudo eselect repository enable certbot-dns-plugins</li>
+    <li>sudo emerge --sync certbot-dns-plugins</li></ol></pre>
+    <h3>Using `layman`</h3>
+    <p>
+        If you're using <a href="https://wiki.gentoo.org/wiki/Layman">layman</a> for managing your overlays, you can simply run:
+    </p>
+    <pre>sudo layman -a certbot-dns-plugins</pre>
+    <h3>Manual overlay installation</h3>
+    <p>
+        If you don't want to use `eselect-repository` or `layman` to manage your overlays, you can also manually install the overlay. Please see the Gentoo Wiki article about <a href="https://wiki.gentoo.org/wiki//etc/portage/repos.conf">/etc/portage/repos.conf</a> for more information.</p>
+    <aside class="note">
+        <div class="note-header">
+            <h3>ACCEPT_KEYWORDS</h3>
+        </div>
+        <p>
+	    All ebuilds have the <a href="https://wiki.gentoo.org/wiki/KEYWORDS">testing KEYWORDS</a> variable set, including potential dependencies from this overlay. Please add the appropriate <a href="https://wiki.gentoo.org/wiki/ACCEPT_KEYWORDS">ACCEPT_KEYWORDS</a> when installing any of the ebuilds.
+	</p>
+    </aside>
+{{/advanced}}
 {{> header}}
 {{>installcertbot}}
 {{> dnspluginssetup}}

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -4,7 +4,10 @@
         <h3>Experimental</h3>
     </div>
     <p>
-        Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay are <strong>experimental</strong> and is not officially supported by Gentoo, Let's Encrypt nor EFF.
+        Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay, which is maintained by a member of the Community voluntarily, are <strong>experimental</strong> and is not officially supported by Gentoo, Let's Encrypt nor EFF.
+    </p>
+    <p>
+        <strong>All contents of the `certbot-dns-plugins` overlay mentioned in these instructions are provided "AS IS".</strong>
     </p>
 </aside>
 <li>

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -10,7 +10,7 @@
 <li>
     Enable the `certbot-dns-plugins` overlay
     <p>
-        If you require any other DNS plugin other than the <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a> plugin, you will need the required ebuilds to install them. An <a href="https://wiki.gentoo.org/wiki/Ebuild_repository">overlay</a> called <a href="https://github.com/gentoo-mirror/certbot-dns-plugins">certbot-dns-plugins</a> exists with all other certbot DNS plugins. To be able to use those ebuilds, you will need to add the aformentioned overlay.
+        If you require any DNS plugin other than the <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a> plugin, you will need the required ebuilds to install them. An <a href="https://wiki.gentoo.org/wiki/Ebuild_repository">overlay</a> called <a href="https://github.com/gentoo-mirror/certbot-dns-plugins">certbot-dns-plugins</a> exists with all other certbot DNS plugins. To be able to use those ebuilds, you will need to add the aformentioned overlay.
     </p>
     <h3>Using `eselect`</h3>
     <p>
@@ -38,6 +38,7 @@
 	    All ebuilds have the <a href="https://wiki.gentoo.org/wiki/KEYWORDS">testing KEYWORDS</a> variable set, including potential dependencies from this overlay. Please add the appropriate <a href="https://wiki.gentoo.org/wiki/ACCEPT_KEYWORDS">ACCEPT_KEYWORDS</a> when installing any of the ebuilds.
 	</p>
     </aside>
+</li>
 {{/advanced}}
 {{> header}}
 {{>installcertbot}}

--- a/_scripts/instruction-widget/templates/install/gentoo.html
+++ b/_scripts/instruction-widget/templates/install/gentoo.html
@@ -6,9 +6,15 @@
     <p>
         Currently, the only packaged certbot DNS plugin in the official Gentoo repository is <a href="https://packages.gentoo.org/packages/app-crypt/certbot-dns-nsone">app-crypt/certbot-dns-nsone</a>. The instructions below pertaining the use of an overlay, which is maintained by a member of the Community voluntarily, are <strong>experimental</strong> and is not officially supported by Gentoo, Let's Encrypt nor EFF.
     </p>
+    <div class="note-header">
+    <h3>Bug reporting</h3>
+    </div>
     <p>
-        <strong>All contents of the `certbot-dns-plugins` overlay mentioned in these instructions are provided "AS IS".</strong>
+        If you encounter a problem with or a bug in an ebuild in the `certbot-dns-plugins` overlay, please open an issue on the <a href="https://github.com/osirisinferi/certbot-dns-plugins-overlay/issues">issues page on the overlays Github repository</a> or open a ticket on <a href="https://bugs.gentoo.org/">Gentoo's Bugzilla</a>. When using Gentoo's Bugzilla, please explicitly mention the overlay using "::certbot-dns-plugins" to ensure that the bug is properly assigned to the repository owner.
     </p>
+    <div class="note-header">
+    <h1>All contents of the `certbot-dns-plugins` overlay mentioned in these instructions are provided "AS IS".</h1>
+    </div>
 </aside>
 <li>
     Enable the `certbot-dns-plugins` overlay


### PR DESCRIPTION
Some time ago I already made a [Gentoo Overlay](https://wiki.gentoo.org/wiki/Ebuild_repository) with the certbot DNS plugins for Gentoo users who might find this useful. But I didn't make the time to add this overlay to the [list of overlays managed by Gentoo](https://overlays.gentoo.org/), so it was very cumbersome to use it. Today, I've requested my overlay to be added to the Gentoo list of overlays and it was [approved](https://github.com/gentoo/api-gentoo-org/commit/6fd0aa5e01aa2e3c22c58769c3b1bea45571a71a). See the [official Gentoo mirror with my overlay](https://github.com/gentoo-mirror/certbot-dns-plugins) :blush: 

This makes it quite easily for Gentoo users to use any of the DNS plugins. However, the current [certbot instructions for a wildcard with Gentoo](https://certbot.eff.org/lets-encrypt/gentoo-other#wildcard) show the Docker method. :cry:

This tiny PR changes this to the official method of installing Gentoo packages.

**However**: users need to enable the overlay *first*, so I would like to add some extra instructions to the DNS plugin installation text.. But I don't see *how*, as `_scripts/instruction-widget/templates/install/dnsplugins.html` only contains generic instructions. **Is it possible to add OS-specific instructions to `dnsplugins.html`?**