### PR TITLE
Add pip instructions

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -40,7 +40,7 @@
         },
         {
             "name": "pip",
-            "id": "pip",
+            "id": "python",
             "distro": "pip",
             "version": "0"
         },

--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -40,7 +40,7 @@
         },
         {
             "name": "pip",
-            "id": "python",
+            "id": "pip",
             "distro": "pip",
             "version": "0"
         },
@@ -165,9 +165,15 @@
           "version": "15.0"
         },
         {
-            "name": "Other Linux",
-            "id": "pip",
-            "distro": "linux",
+            "name": "Other Linux (snapd)",
+            "id": "othersnap",
+            "distro": "snap",
+            "version": "0"
+        },
+        {
+            "name": "Other Linux (pip)",
+            "id": "otherpip",
+            "distro": "pip",
             "version": "0"
         },
         {

--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -39,6 +39,12 @@
             "version": "0"
         },
         {
+            "name": "pip",
+            "id": "pip",
+            "distro": "pip",
+            "version": "0"
+        },
+        {
             "name": "Debian 9 (stretch)",
             "id": "debianstretch",
             "distro": "debian",

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -53,6 +53,8 @@ module.exports = function(context) {
       macos_install();
     } else if (context.distro == "devuan" && context.version > 1) {
       debian_install();
+    } else if (context.distro == "pip") {
+      pip_install();
     } else {
       snap_install();
     }
@@ -259,6 +261,17 @@ module.exports = function(context) {
     context.package = "--classic certbot";
     context.dns_plugins = true;
     context.dns_package_prefix = "certbot-dns";
+  }
+
+  pip_install == function () {
+    template = "pip";
+    context.base_command = "/opt/certbot/bin/certbot";
+    context.cron_included = false;
+    context.install_command = "pip install";
+    context.package = "certbot";
+    context.dns_plugins = true;
+    context.dns_package_prefix = "certbot-dns";
+    context.python_name = "/opt/certbot/bin/python3";
   }
 
   // This function is currently unused, but we keep it around to make it easy

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -263,7 +263,7 @@ module.exports = function(context) {
     context.dns_package_prefix = "certbot-dns";
   }
 
-  pip_install == function () {
+  pip_install = function () {
     template = "pip";
     context.base_command = "/opt/certbot/bin/certbot";
     context.cron_included = false;

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -62,7 +62,7 @@ module.exports = function(context) {
     partials.auto = require(TEMPLATE_PATH + "commonauto.html");
     partials.header = require(TEMPLATE_PATH + "header.html");
     partials.installcertbot = require(TEMPLATE_PATH + "installcertbot.html");
-    partials.preparecertbotsnapcommand = require(TEMPLATE_PATH + "preparecertbotsnapcommand.html");
+    partials.preparecertbotsymlinkcommand = require(TEMPLATE_PATH + "preparecertbotsymlinkcommand.html");
     partials.dnsplugins = require(TEMPLATE_PATH + "dnsplugins.html");
     partials.dnspluginssetup = require(TEMPLATE_PATH + "dnspluginssetup.html");
 
@@ -261,11 +261,12 @@ module.exports = function(context) {
     context.package = "--classic certbot";
     context.dns_plugins = true;
     context.dns_package_prefix = "certbot-dns";
+    context.original_certbot_location = "/snap/bin";
   }
 
   pip_install = function () {
     template = "pip";
-    context.base_command = "/opt/certbot/bin/certbot";
+    context.base_command = "certbot";
     context.cron_included = false;
     context.install_command = "sudo /opt/certbot/bin/pip install";
     context.package = "certbot";
@@ -277,6 +278,7 @@ module.exports = function(context) {
     context.dns_plugins = true;
     context.dns_package_prefix = "certbot-dns";
     context.python_name = "/opt/certbot/bin/python3";
+    context.original_certbot_location = "/opt/certbot/bin";
   }
 
   // This function is currently unused, but we keep it around to make it easy

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -279,6 +279,7 @@ module.exports = function(context) {
     context.dns_package_prefix = "certbot-dns";
     context.python_name = "/opt/certbot/bin/python";
     context.original_certbot_location = "/opt/certbot/bin";
+    context.upgrade_instructions = true;
   }
 
   // This function is currently unused, but we keep it around to make it easy

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -277,7 +277,7 @@ module.exports = function(context) {
     }
     context.dns_plugins = true;
     context.dns_package_prefix = "certbot-dns";
-    context.python_name = "/opt/certbot/bin/python3";
+    context.python_name = "/opt/certbot/bin/python";
     context.original_certbot_location = "/opt/certbot/bin";
   }
 

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -267,8 +267,13 @@ module.exports = function(context) {
     template = "pip";
     context.base_command = "/opt/certbot/bin/certbot";
     context.cron_included = false;
-    context.install_command = "pip install";
+    context.install_command = "sudo /opt/certbot/bin/pip install";
     context.package = "certbot";
+    if (context.webserver == "apache") {
+      context.package += " certbot-apache";
+    } else if (context.webserver == "nginx") {
+      context.package += " certbot-nginx";
+    }
     context.dns_plugins = true;
     context.dns_package_prefix = "certbot-dns";
     context.python_name = "/opt/certbot/bin/python3";

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -73,3 +73,16 @@
   look for the lock icon in the URL bar.
   </p>
 </li>
+
+{{#upgrade_instructions}}
+<li>
+  [Optional] Upgrade certbot
+  <p>When you're ready to upgrade certbot, run the following command on the command line on the machine.
+    <pre class="no-before"><ol>
+        <li>{{install_command}} --upgrade {{package}}</li></ol></pre>
+    </p>
+
+  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
+  <p>For automatic upgrades, the command in this step can be run by a monthly cron job.</p>
+</li>
+{{/upgrade_instructions}}

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -76,8 +76,9 @@
 
 {{#upgrade_instructions}}
 <li>
-  [Optional] Upgrade certbot
-  <p>When you're ready to upgrade certbot, run the following command on the command line on the machine.
+  [Monthly] Upgrade certbot
+  <p>It's important to occasionally update Certbot to keep it up-to-date. To do this, run the
+    following command on the command line on the machine.
     <pre class="no-before"><ol>
         <li>{{install_command}} --upgrade {{package}}</li></ol></pre>
     </p>

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -84,6 +84,5 @@
     </p>
 
   <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
-  <p>For automatic upgrades, the command in this step can be run by a monthly cron job.</p>
 </li>
 {{/upgrade_instructions}}

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -80,9 +80,11 @@
   <p>It's important to occasionally update Certbot to keep it up-to-date. To do this, run the
     following command on the command line on the machine.
     <pre class="no-before"><ol>
-        <li>{{install_command}} --upgrade {{package}}</li></ol></pre>
+        <li>{{install_command}} --upgrade {{package}}{{#advanced}} certbot-dns-&lt;PLUGIN&gt;{{/advanced}}</li></ol></pre>
     </p>
 
-  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
+  {{#advanced}}<p>As above, replace <code>&lt;PLUGIN&gt;</code> with the name of your DNS provider.</p>{{/advanced}}
+
+  <p>If this step leads to errors, run <code>sudo rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
 </li>
 {{/upgrade_instructions}}

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -37,7 +37,7 @@
     "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
 </li>
 <li>
-  Set up a venv
+  Set up a Python virtual environment
   <p>
   Execute the following instructions on the command line on the machine to set up a virtual
   environment.

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -13,8 +13,8 @@
 <li>
     Install system dependencies
 
-    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python3-dev</code>,
-      <code>python3-devel</code>, or <code>python3-venv</code>) and Augeas for the Apache
+    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python3</code>,
+      <code>python3</code>, or <code>python3-venv</code>) and Augeas for the Apache
       plugin (<code>libaugeas0</code> or <code>augeaslibs</code>).</p>
 
     <p>If you're having trouble installing cryptography, you may need to install additional
@@ -30,7 +30,7 @@
         <li># For RPM-based distributions (e.g. Fedora, CentOS ...)</li>
         <li># NB1: old distributions will use yum instead of dnf</li>
         <li># NB2: RHEL-based distributions use python3X instead of python3 (e.g. python36)</li>
-        <li>sudo dnf install python3-devel augeas-libs redhat-rpm-config</li></ol></pre>
+        <li>sudo dnf install python3 augeas-libs redhat-rpm-config</li></ol></pre>
     </p>
 
     <p>These packages may have slightly different names on other distributions; a search such as

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -45,12 +45,12 @@
     Remove certbot-auto and any Certbot OS packages
     <p>
     If you have any Certbot packages installed using an OS package manager like
-    <tt>apt</tt>, <tt>dnf</tt>, or <tt>yum</tt>, you should remove them before
+    <code>apt</code>, <code>dnf</code>, or <code>yum</code>, you should remove them before
     installing the Certbot snap to ensure that when you run the command
-    <tt>certbot</tt> the snap is used rather than the installation from your OS
+    <code>certbot</code> the snap is used rather than the installation from your OS
     package manager. The exact command to do this depends on your OS, but
-    common examples are <tt>sudo apt-get remove certbot</tt>, <tt>sudo dnf
-    remove certbot</tt>, or <tt>sudo yum remove certbot</tt>.
+    common examples are <code>sudo apt-get remove certbot</code>, <code>sudo dnf
+    remove certbot</code>, or <code>sudo yum remove certbot</code>.
     </p>
     <p>
     If you previously used Certbot through the certbot-auto script, you should

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -51,16 +51,6 @@
 {{> installcertbot}}
 {{>preparecertbotsymlinkcommand}}
 
-<li>
-    [Optional] Install any custom third-party plugins
-    <p>
-    If you use third-party plugins not created by the Certbot team, you can install them by
-    executing the following command on the command line on the machine.
-    <pre class="no-before"><ol>
-        <li>{{install_command}} &lt;other-plugins&gt;</li></ol></pre>
-    </p>
-</li>
-
 
 {{#advanced}}
 {{#dns_plugins}}

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -37,7 +37,7 @@
     "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
 </li>
 <li>
-  Set up a venv with certbot installed
+  Set up a venv
   <p>
   Execute the following instructions on the command line on the machine to set up a virtual
   environment.
@@ -45,40 +45,26 @@
         <li>python3 -m venv /opt/certbot/</li>
         <li>. /opt/certbot/bin/activate</li>
         <li>pip install --upgrade pip</li>
-        <li>pip install certbot certbot-apache certbot-nginx</li>
         <li>deactivate</li>
         <li>exit</li></ol></pre>
   </p>
 </li>
+
+{{> installcertbot}}
+
 <li>
     [Optional] Install any custom third-party plugins
     <p>
     If you use third-party plugins not created by the Certbot team, you can install them by
-    executing the following instructions on the command line on the machine.
-    <pre class="no-before"><ol><li>sudo su</li>
-        <li>. /opt/certbot/bin/activate</li>
-        <li>pip install &lt;other-plugins&gt;</li>
-        <li>deactivate</li>
-        <li>exit</li></ol></pre>
+    executing the following command on the command line on the machine.
+    <pre class="no-before"><ol>
+        <li>sudo /opt/certbot/bin/pip install &lt;other-plugins&gt;</li></ol></pre>
     </p>
 </li>
 
 
 {{#advanced}}
 {{#dns_plugins}}
-<li>
-  Confirm plugin containment level
-  <p>
-  Run this command on the command line on the machine to acknowledge that the installed
-  plugin will have the same <tt>classic</tt> containment as the Certbot snap.
-  </p>
-  <pre>sudo snap set certbot trust-plugin-with-root=ok</pre>
-
-  <p>
-  If you encounter issues with running Certbot, you may need to follow this step, then
-  the "Install correct DNS plugin" step, again.
-  </p>
-</li>
 {{/dns_plugins}}
 {{/advanced}}
 
@@ -86,16 +72,13 @@
 
 <li>
   [Optional] Upgrade certbot
-  <p>When you're ready to upgrade certbot, run the following commands on the command line on the machine.
-    <pre class="no-before"><ol><li>sudo su</li>
-        <li>. /opt/certbot/bin/activate</li>
-        <li>pip install --upgrade certbot certbot-apache certbot-nginx</li>
-        <li>deactivate</li>
-        <li>exit</li></ol></pre>
+  <p>When you're ready to upgrade certbot, run the following command on the command line on the machine.
+    <pre class="no-before"><ol>
+        <li>sudo /opt/certbot/bin/pip install --upgrade certbot certbot-apache certbot-nginx</li></ol></pre>
     </p>
 
   <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat the instructions
   from "Set up a venv with certbot installed",{{#advanced}} DNS plugin installation instructions,{{/advanced}}
-  (and "Install any custom third-party plugins" if needed).</p>
-  <p>For automatic upgrades, lines 2-4 of these instructions can be run by a monthly cron job.</p>
+  and "Install any custom third-party plugins" if needed.</p>
+  <p>For automatic upgrades, the command in this step can be run by a monthly cron job.</p>
 </li>

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -51,6 +51,7 @@
 </li>
 
 {{> installcertbot}}
+{{>preparecertbotsymlinkcommand}}
 
 <li>
     [Optional] Install any custom third-party plugins

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -31,11 +31,12 @@
       </ol></pre>
     </p>
     <p>For RPM-based distributions (e.g. Fedora, CentOS ...):
-    <br>NB1: old distributions will use yum instead of dnf
-    <br>NB2: RHEL-based distributions use <code>python3X</code> instead of <code>python3</code>
-      (e.g. <code>python36</code>)
       <pre class="no-before"><ol>
-        <li>sudo dnf install python3 augeas-libs</li></ol></pre>
+        <li>sudo dnf install python3 augeas-libs</li></ol></pre></p>
+    <p>
+      * Note that old distributions use <code>yum</code> instead of <code>dnf</code>, and that
+      RHEL-based distributions use <code>python3X</code> instead of <code>python3</code>
+      (e.g. <code>python36</code>).
     </p>
 
     <p>These packages may have slightly different names on other distributions; a search such as

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -41,12 +41,10 @@
   <p>
   Execute the following instructions on the command line on the machine to set up a virtual
   environment.
-  <pre class="no-before"><ol><li>sudo su</li>
-        <li>python3 -m venv /opt/certbot/</li>
-        <li>. /opt/certbot/bin/activate</li>
-        <li>pip install --upgrade pip</li>
-        <li>deactivate</li>
-        <li>exit</li></ol></pre>
+  <pre class="no-before"><ol>
+        <li>sudo python3 -m venv /opt/certbot/</li>
+        <li>{{install_command}} --upgrade pip</li>
+  </ol></pre>
   </p>
 </li>
 
@@ -59,7 +57,7 @@
     If you use third-party plugins not created by the Certbot team, you can install them by
     executing the following command on the command line on the machine.
     <pre class="no-before"><ol>
-        <li>sudo /opt/certbot/bin/pip install &lt;other-plugins&gt;</li></ol></pre>
+        <li>{{install_command}} &lt;other-plugins&gt;</li></ol></pre>
     </p>
 </li>
 
@@ -75,11 +73,9 @@
   [Optional] Upgrade certbot
   <p>When you're ready to upgrade certbot, run the following command on the command line on the machine.
     <pre class="no-before"><ol>
-        <li>sudo /opt/certbot/bin/pip install --upgrade certbot certbot-apache certbot-nginx</li></ol></pre>
+        <li>{{install_command}} --upgrade {{package}}</li></ol></pre>
     </p>
 
-  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat the instructions
-  from "Set up a venv with certbot installed",{{#advanced}} DNS plugin installation instructions,{{/advanced}}
-  and "Install any custom third-party plugins" if needed.</p>
+  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
   <p>For automatic upgrades, the command in this step can be run by a monthly cron job.</p>
 </li>

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -35,7 +35,7 @@
     <br>NB2: RHEL-based distributions use <code>python3X</code> instead of <code>python3</code>
       (e.g. <code>python36</code>)
       <pre class="no-before"><ol>
-        <li>sudo dnf install python3 augeas-libs redhat-rpm-config</li></ol></pre>
+        <li>sudo dnf install python3 augeas-libs</li></ol></pre>
     </p>
 
     <p>These packages may have slightly different names on other distributions; a search such as

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -37,6 +37,23 @@
     "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
 </li>
 <li>
+    Remove certbot-auto and any Certbot OS packages
+    <p>
+    If you have any Certbot packages installed using an OS package manager like
+    <tt>apt</tt>, <tt>dnf</tt>, or <tt>yum</tt>, you should remove them before
+    installing the Certbot snap to ensure that when you run the command
+    <tt>certbot</tt> the snap is used rather than the installation from your OS
+    package manager. The exact command to do this depends on your OS, but
+    common examples are <tt>sudo apt-get remove certbot</tt>, <tt>sudo dnf
+    remove certbot</tt>, or <tt>sudo yum remove certbot</tt>.
+    </p>
+    <p>
+    If you previously used Certbot through the certbot-auto script, you should
+    also remove its installation by following the instructions <a
+    href="/docs/uninstall.html">here</a>.
+    </p>
+</li>
+<li>
   Set up a Python virtual environment
   <p>
   Execute the following instructions on the command line on the machine to set up a virtual

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -59,13 +59,3 @@
 
 {{> dnspluginssetup}}
 
-<li>
-  [Optional] Upgrade certbot
-  <p>When you're ready to upgrade certbot, run the following command on the command line on the machine.
-    <pre class="no-before"><ol>
-        <li>{{install_command}} --upgrade {{package}}</li></ol></pre>
-    </p>
-
-  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat all installation instructions.</p>
-  <p>For automatic upgrades, the command in this step can be run by a monthly cron job.</p>
-</li>

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -26,7 +26,7 @@
     line on the machine:
       <pre class="no-before"><ol><li># For APT-based distributions (e.g. Debian, Ubuntu ...)</li>
         <li>sudo apt update</li>
-        <li>sudo apt install python3-dev python3-venv libaugeas0</li>
+        <li>sudo apt install python3 python3-venv libaugeas0</li>
         <li># For RPM-based distributions (e.g. Fedora, CentOS ...)</li>
         <li># NB1: old distributions will use yum instead of dnf</li>
         <li># NB2: RHEL-based distributions use python3X-devel instead of python3-devel (e.g. python36-devel)</li>

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -29,7 +29,7 @@
         <li>sudo apt install python3 python3-venv libaugeas0</li>
         <li># For RPM-based distributions (e.g. Fedora, CentOS ...)</li>
         <li># NB1: old distributions will use yum instead of dnf</li>
-        <li># NB2: RHEL-based distributions use python3X-devel instead of python3-devel (e.g. python36-devel)</li>
+        <li># NB2: RHEL-based distributions use python3X instead of python3 (e.g. python36)</li>
         <li>sudo dnf install python3-devel augeas-libs redhat-rpm-config</li></ol></pre>
     </p>
 

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -1,0 +1,110 @@
+{{> header}}
+<li>
+    Install system dependencies
+
+    <p>These include:
+      <ul>
+        <li>Python 3.6+, including venv. This might be called <code>python3-dev</code>,
+          <code>python3-devel</code>, or <code>python3-venv</code>.</li>
+        <li>Augeas for the Apache plugin: <code>libaugeas0</code> or <code>augeaslibs</code></li>
+        <li>If you're having trouble installing cryptography, you may need to install additional
+          dependencies. See
+          <a href="https://cryptography.io/en/latest/installation.html#building-cryptography-on-linux">
+          the cryptography project's site</a> for more infoformation.</li>
+      </ul>
+    </p>
+
+    <p>Commands to install system dependencies may look like the following, run on the command
+    line on the machine:</p>
+
+    <pre><code>
+    # For APT-based distributions (e.g. Debian, Ubuntu ...)
+    sudo apt update
+    sudo apt install python3-dev python3-venv libaugeas0
+    # For RPM-based distributions (e.g. Fedora, CentOS ...)
+    # NB1: old distributions will use yum instead of dnf
+    # NB2: RHEL-based distributions use python3X-devel instead of python3-devel (e.g. python36-devel)
+    sudo dnf install python3-devel augeas-libs redhat-rpm-config
+    </code></pre>
+
+    <p>These packages may have slightly different names on other distributions; a search such as
+    "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
+</li>
+<li>
+  Set up a venv with certbot installed
+  <p>
+  Execute the following instructions on the command line on the machine to set up a virtual
+  environment.
+  </p>
+  <pre><code>
+    sudo su
+    python3 -m venv /opt/certbot/
+    . /opt/certbot/bin/activate
+    pip install --upgrade pip
+    pip install certbot certbot-apache certbot-nginx
+    deactivate
+    exit
+  </code></pre>
+</li>
+<li>
+    [Optional] Install any custom third-party plugins
+    <p>
+    If you use third-party plugins not created by the Certbot team, you can install them by
+    executing the following instructions on the command line on the machine.
+    </p>
+    <pre><code>
+      sudo su
+      . /opt/certbot/bin/activate
+      pip install &lt;other-plugins&gt;
+      deactivate
+      exit
+    </code></pre>
+</li>
+
+
+{{#advanced}}
+{{#dns_plugins}}
+<li>
+  Confirm plugin containment level
+  <p>
+  Run this command on the command line on the machine to acknowledge that the installed
+  plugin will have the same <tt>classic</tt> containment as the Certbot snap.
+  </p>
+  <pre>sudo snap set certbot trust-plugin-with-root=ok</pre>
+
+  <p>
+  If you encounter issues with running Certbot, you may need to follow this step, then
+  the "Install correct DNS plugin" step, again.
+  </p>
+</li>
+{{/dns_plugins}}
+{{/advanced}}
+
+{{> dnspluginssetup}}
+
+<li>
+  Upgrade certbot
+  <p>To upgrade certbot, run the following commands on the command line on the machine.</p>
+  <pre><code>
+    sudo su
+    . /opt/certbot/bin/activate
+    pip install --upgrade certbot certbot-apache certbot-nginx
+    deactivate
+    exit
+  </code></pre>
+  <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat the instructions
+  from "Set up a venv with certbot installed",{{#advanced}} DNS plugin installation instructions,{{/advanced}},
+  (and "Install any custom third-party plugins" if needed).</p>
+  <p>For automatic upgrades, lines 2-4 of these instructions can be run by a monthly cron job.</p>
+</li>
+
+<aside class="note">
+  <div class="note-header">
+    <h3>Further Support</h3>
+  </div>
+  <p>
+  The Certbot team supports this installation method on a best effort basis. If you are on
+  a more obscure or heavily customized system, these instructions may not work and the
+  Certbot team may be unable to help you resolve the problem.
+  </p>
+</aside>

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -23,13 +23,18 @@
       the cryptography project's site</a> for more infoformation.</p>
 
     <p>Commands to install system dependencies may look like the following, run on the command
-    line on the machine:
-      <pre class="no-before"><ol><li># For APT-based distributions (e.g. Debian, Ubuntu ...)</li>
+    line on the machine.</p>
+    <p>For APT-based distributions (e.g. Debian, Ubuntu ...):
+      <pre class="no-before"><ol>
         <li>sudo apt update</li>
         <li>sudo apt install python3 python3-venv libaugeas0</li>
-        <li># For RPM-based distributions (e.g. Fedora, CentOS ...)</li>
-        <li># NB1: old distributions will use yum instead of dnf</li>
-        <li># NB2: RHEL-based distributions use python3X instead of python3 (e.g. python36)</li>
+      </ol></pre>
+    </p>
+    <p>For RPM-based distributions (e.g. Fedora, CentOS ...):
+    <br>NB1: old distributions will use yum instead of dnf
+    <br>NB2: RHEL-based distributions use <code>python3X</code> instead of <code>python3</code>
+      (e.g. <code>python36</code>)
+      <pre class="no-before"><ol>
         <li>sudo dnf install python3 augeas-libs redhat-rpm-config</li></ol></pre>
     </p>
 

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -1,31 +1,37 @@
+<aside class="note">
+  <div class="note-header">
+    <h3>Partial support</h3>
+  </div>
+  <p>
+  The Certbot team supports this installation method on a best effort basis. If you are on
+  a more obscure or heavily customized system, these instructions may not work and the
+  Certbot team may be unable to help you resolve the problem.
+  </p>
+</aside>
+
 {{> header}}
 <li>
     Install system dependencies
 
-    <p>These include:
-      <ul>
-        <li>Python 3.6+, including venv. This might be called <code>python3-dev</code>,
-          <code>python3-devel</code>, or <code>python3-venv</code>.</li>
-        <li>Augeas for the Apache plugin: <code>libaugeas0</code> or <code>augeaslibs</code></li>
-        <li>If you're having trouble installing cryptography, you may need to install additional
-          dependencies. See
-          <a href="https://cryptography.io/en/latest/installation.html#building-cryptography-on-linux">
-          the cryptography project's site</a> for more infoformation.</li>
-      </ul>
-    </p>
+    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python3-dev</code>,
+      <code>python3-devel</code>, or <code>python3-venv</code>) and Augeas for the Apache
+      plugin (<code>libaugeas0</code> or <code>augeaslibs</code>).</p>
+
+    <p>If you're having trouble installing cryptography, you may need to install additional
+      dependencies. See
+      <a href="https://cryptography.io/en/latest/installation.html#building-cryptography-on-linux">
+      the cryptography project's site</a> for more infoformation.</p>
 
     <p>Commands to install system dependencies may look like the following, run on the command
-    line on the machine:</p>
-
-    <pre><code>
-    # For APT-based distributions (e.g. Debian, Ubuntu ...)
-    sudo apt update
-    sudo apt install python3-dev python3-venv libaugeas0
-    # For RPM-based distributions (e.g. Fedora, CentOS ...)
-    # NB1: old distributions will use yum instead of dnf
-    # NB2: RHEL-based distributions use python3X-devel instead of python3-devel (e.g. python36-devel)
-    sudo dnf install python3-devel augeas-libs redhat-rpm-config
-    </code></pre>
+    line on the machine:
+      <pre class="no-before"><ol><li># For APT-based distributions (e.g. Debian, Ubuntu ...)</li>
+        <li>sudo apt update</li>
+        <li>sudo apt install python3-dev python3-venv libaugeas0</li>
+        <li># For RPM-based distributions (e.g. Fedora, CentOS ...)</li>
+        <li># NB1: old distributions will use yum instead of dnf</li>
+        <li># NB2: RHEL-based distributions use python3X-devel instead of python3-devel (e.g. python36-devel)</li>
+        <li>sudo dnf install python3-devel augeas-libs redhat-rpm-config</li></ol></pre>
+    </p>
 
     <p>These packages may have slightly different names on other distributions; a search such as
     "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
@@ -35,30 +41,26 @@
   <p>
   Execute the following instructions on the command line on the machine to set up a virtual
   environment.
+  <pre class="no-before"><ol><li>sudo su</li>
+        <li>python3 -m venv /opt/certbot/</li>
+        <li>. /opt/certbot/bin/activate</li>
+        <li>pip install --upgrade pip</li>
+        <li>pip install certbot certbot-apache certbot-nginx</li>
+        <li>deactivate</li>
+        <li>exit</li></ol></pre>
   </p>
-  <pre><code>
-    sudo su
-    python3 -m venv /opt/certbot/
-    . /opt/certbot/bin/activate
-    pip install --upgrade pip
-    pip install certbot certbot-apache certbot-nginx
-    deactivate
-    exit
-  </code></pre>
 </li>
 <li>
     [Optional] Install any custom third-party plugins
     <p>
     If you use third-party plugins not created by the Certbot team, you can install them by
     executing the following instructions on the command line on the machine.
+    <pre class="no-before"><ol><li>sudo su</li>
+        <li>. /opt/certbot/bin/activate</li>
+        <li>pip install &lt;other-plugins&gt;</li>
+        <li>deactivate</li>
+        <li>exit</li></ol></pre>
     </p>
-    <pre><code>
-      sudo su
-      . /opt/certbot/bin/activate
-      pip install &lt;other-plugins&gt;
-      deactivate
-      exit
-    </code></pre>
 </li>
 
 
@@ -83,28 +85,17 @@
 {{> dnspluginssetup}}
 
 <li>
-  Upgrade certbot
-  <p>To upgrade certbot, run the following commands on the command line on the machine.</p>
-  <pre><code>
-    sudo su
-    . /opt/certbot/bin/activate
-    pip install --upgrade certbot certbot-apache certbot-nginx
-    deactivate
-    exit
-  </code></pre>
+  [Optional] Upgrade certbot
+  <p>When you're ready to upgrade certbot, run the following commands on the command line on the machine.
+    <pre class="no-before"><ol><li>sudo su</li>
+        <li>. /opt/certbot/bin/activate</li>
+        <li>pip install --upgrade certbot certbot-apache certbot-nginx</li>
+        <li>deactivate</li>
+        <li>exit</li></ol></pre>
+    </p>
+
   <p>If this step leads to errors, run <code>rm -rf /opt/certbot</code> and repeat the instructions
-  from "Set up a venv with certbot installed",{{#advanced}} DNS plugin installation instructions,{{/advanced}},
+  from "Set up a venv with certbot installed",{{#advanced}} DNS plugin installation instructions,{{/advanced}}
   (and "Install any custom third-party plugins" if needed).</p>
   <p>For automatic upgrades, lines 2-4 of these instructions can be run by a monthly cron job.</p>
 </li>
-
-<aside class="note">
-  <div class="note-header">
-    <h3>Further Support</h3>
-  </div>
-  <p>
-  The Certbot team supports this installation method on a best effort basis. If you are on
-  a more obscure or heavily customized system, these instructions may not work and the
-  Certbot team may be unable to help you resolve the problem.
-  </p>
-</aside>

--- a/_scripts/instruction-widget/templates/install/preparecertbotsymlinkcommand.html
+++ b/_scripts/instruction-widget/templates/install/preparecertbotsymlinkcommand.html
@@ -4,5 +4,5 @@
   Execute the following instruction on the command line on the machine to ensure
   that the <tt>certbot</tt> command can be run.
   </p>
-  <pre>sudo ln -s /snap/bin/certbot /usr/bin/certbot</pre>
+  <pre>sudo ln -s {{original_certbot_location}}/certbot /usr/bin/certbot</pre>
 </li>

--- a/_scripts/instruction-widget/templates/install/snap.html
+++ b/_scripts/instruction-widget/templates/install/snap.html
@@ -47,7 +47,7 @@
 </li>
 
 {{>installcertbot}}
-{{>preparecertbotsnapcommand}}
+{{>preparecertbotsymlinkcommand}}
 
 {{#advanced}}
 {{#dns_plugins}}


### PR DESCRIPTION
Questions:
- Should we give people the command to upgrade certbot monthly via cron and remove [Optional]?
- Should we switch to recommending people blow away the venv each time?
- Should the upgrade instruction be down below with renewal, so people can do the most important things first? It's a little more work (it'll need to be moved into a different partial) but super doable.
- We don't mention third-party plugins elsewhere; should we remove that from here?
- What should the system name in the uri and the dropdown/title be?

dropdown and heading:
![Screenshot from 2021-02-25 15-19-36](https://user-images.githubusercontent.com/1227205/109232275-e82f5c00-777c-11eb-8686-57aee4e26e89.png)

default instructions:
![Screenshot from 2021-02-25 15-17-18](https://user-images.githubusercontent.com/1227205/109232127-a56d8400-777c-11eb-90fc-c30799e709c1.png)
![Screenshot from 2021-02-25 15-17-34](https://user-images.githubusercontent.com/1227205/109232126-a56d8400-777c-11eb-84b7-b729e71ccbaf.png)
![Screenshot from 2021-02-25 15-17-44](https://user-images.githubusercontent.com/1227205/109232125-a4d4ed80-777c-11eb-97b7-3318a7aa3b29.png)

wildcard instructions:
![Screenshot from 2021-02-25 15-18-50](https://user-images.githubusercontent.com/1227205/109232219-cdf57e00-777c-11eb-8621-093ea351f777.png)
