### PR TITLE
Add Vimexx to hosting provider list with 'partial' support

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1937,7 +1937,7 @@
     "announcement": "https://www.vimexx.nl/news/gratis-wildcard-ssl-via-lets-encrypt",
     "plan": "",
     "reviewed": "2021.2.28",
-    "note": ""
+    "note": "The website is in Dutch."
   },
   {
     "name": "VIPserv.org",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1930,6 +1930,16 @@
     "note": ""
   },
   {
+    "name": "Vimexx",
+    "link": "",
+    "category": "partial",
+    "tutorial": "https://www.vimexx.nl/help/gratis-lets-encrypt-ssl-op-je-website-installeren",
+    "announcement": "https://www.vimexx.nl/news/gratis-wildcard-ssl-via-lets-encrypt",
+    "plan": "",
+    "reviewed": "2021.2.28",
+    "note": ""
+  },
+  {
     "name": "VIPserv.org",
     "link": "",
     "category": "partial",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1931,7 +1931,7 @@
   },
   {
     "name": "Vimexx",
-    "link": "",
+    "link": "https://www.vimexx.nl/",
     "category": "partial",
     "tutorial": "https://www.vimexx.nl/help/gratis-lets-encrypt-ssl-op-je-website-installeren",
     "announcement": "https://www.vimexx.nl/news/gratis-wildcard-ssl-via-lets-encrypt",


### PR DESCRIPTION
On the Community, I came across [a thread](https://community.letsencrypt.org/t/privacy-error-in-chrome/146336) mentioning a specific (Dutch) hosting provider providing Let's Encrypt support through DirectAdmin.

Link to tutorial: https://www.vimexx.nl/help/gratis-lets-encrypt-ssl-op-je-website-installeren
Link to announcement: https://www.vimexx.nl/news/gratis-wildcard-ssl-via-lets-encrypt

(All in Dutch without English translation as far as I can see unfortunately.)

They don't seem to enable HTTPS by default, but only on request of the user through DirectAdmin, so I suppose it's partial support.