### PR TITLE
instructions: add Bitnami to the distro list

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -33,6 +33,12 @@
             "version": "0"
         },
         {
+            "name": "Bitnami",
+            "id": "bitnami",
+            "distro": "bitnami",
+            "version": 0
+        },
+        {
             "name": "snapd",
             "id": "snap",
             "distro": "snap",

--- a/_scripts/instruction-widget/get-started.js
+++ b/_scripts/instruction-widget/get-started.js
@@ -10,6 +10,8 @@ module.exports = function(context) {
         context.imperative = "you'll have to";
         if (context.webserver == "plesk") {
             plesk_getting_started();
+        } else if (context.distro == "bitnami") {
+            bitnami_getting_started();
         } else if (context.distro == "sharedhost") {
             shared_hosting_getting_started();
         } else if (context.distro == "windows") {
@@ -45,6 +47,10 @@ module.exports = function(context) {
 
     plesk_getting_started = function() {
         template = "plesk";
+    }
+
+    bitnami_getting_started = function() {
+        template = "bitnami";
     }
 
     certonly_getting_started = function() {

--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -33,7 +33,7 @@ module.exports = function(context) {
     // Each case listed here should map to a template.
     // They don't necessarily need to map to distros.
     if (context.webserver == "plesk" || context.distro == "windows" ||
-        context.distro == "sharedhost") {
+        context.distro == "bitnami" || context.distro == "sharedhost") {
         return '';
     }
     else if (snap_distros.includes(context.distro)) {

--- a/_scripts/instruction-widget/templates/getting-started/bitnami.html
+++ b/_scripts/instruction-widget/templates/getting-started/bitnami.html
@@ -1,0 +1,9 @@
+<p>Are you running your website using a Bitnami template or server?</p>
+<p>
+  Bitnami offers its own tools and instructions to get your site running on HTTPS. Follow along at
+  <a href="https://docs.bitnami.com/general/how-to/generate-install-lets-encrypt-ssl/">
+    https://docs.bitnami.com/general/how-to/generate-install-lets-encrypt-ssl/</a>.
+</p>
+<p>
+  We recommend following these official instructions instead of using Certbot.
+</p>


### PR DESCRIPTION
This points readers to the official Bitnami documentation, which offers
its own 'bntool' and alternatives.

---

Fixes #612. 

Since filing that issue, my feeling is that Bitnami+Certbot not working has continued to be a problem for users. We have an opportunity on the website to prevent those issues and questions.

I wasn't entirely sure whether Bitnami belongs to the Webserver or Distro dropdowns. The Distro dropdown felt like a more natural fit because Bitnami supports different webservers and I have a feeling that users install it, more often than not, as an "OS image".

[Screenshot](https://user-images.githubusercontent.com/311534/109960542-0547ca00-7d3d-11eb-980e-1bd866f977e0.png).
