### PR TITLE
Fix pip typo

### DIFF
--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -13,9 +13,8 @@
 <li>
     Install system dependencies
 
-    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python</code>,
-      <code>python3</code>, or <code>python3-venv</code>) and Augeas for the Apache
-      plugin (<code>libaugeas0</code> or <code>augeaslibs</code>).</p>
+    <p>System dependencies may include Python 3.6+ including the venv module
+    and Augeas for the Apache plugin.</p>
 
     <p>If you're having trouble installing cryptography, you may need to install additional
       dependencies. See

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -13,7 +13,7 @@
 <li>
     Install system dependencies
 
-    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python3</code>,
+    <p>System dependencies may include Python 3.6+, including venv (this might be called <code>python</code>,
       <code>python3</code>, or <code>python3-venv</code>) and Augeas for the Apache
       plugin (<code>libaugeas0</code> or <code>augeaslibs</code>).</p>
 


### PR DESCRIPTION
The parenthetical currently says:

> this might be called python3, python3, or python3-venv

I started to just fix this by talking about `python3X` such as `python36`, but we include that same information in the sentences below. Rather than duplicating the information here, I figured we could just simplify this sentence and keep the system specific details in one place.