### PR TITLE
Update docs submodule

### DIFF
--- a/_docs.sh
+++ b/_docs.sh
@@ -7,11 +7,11 @@ case "$1" in
     sudo apt-get update
     sudo apt-get install python3-dev python3-venv gcc libaugeas0 libssl-dev \
                          libffi-dev ca-certificates openssl -y
-    ./tools/venv3.py
+    ./tools/venv.py
     ;;
   "install" )
     cd _docs
-    source ./venv3/bin/activate
+    source ./venv/bin/activate
     pip install --upgrade git+https://github.com/EFForg/sphinx_rtd_theme.git
     cd certbot
     make -C docs clean html epub latex latexpdf > /dev/null


### PR DESCRIPTION
The diff of the changes to `certbot/docs` in this PR is:
```
diff --git a/certbot/docs/api/certbot.compat.os.rst b/certbot/docs/api/certbot.compat.os.rst
index 3a4c9fe47..c46cee668 100644
--- a/certbot/docs/api/certbot.compat.os.rst
+++ b/certbot/docs/api/certbot.compat.os.rst
@@ -2,6 +2,4 @@ certbot.compat.os module
 ========================
 
 .. automodule:: certbot.compat.os
-    :members:
-    :undoc-members:
-    :show-inheritance:
+    :members: chmod, umask, chown, open, mkdir, makedirs, rename, replace, access, stat, fstat
diff --git a/certbot/docs/cli-help.txt b/certbot/docs/cli-help.txt
index a320b30e8..c5490c100 100644
--- a/certbot/docs/cli-help.txt
+++ b/certbot/docs/cli-help.txt
@@ -99,9 +99,9 @@ optional arguments:
                         before submitting to CA (default: False)
   --preferred-chain PREFERRED_CHAIN
                         If the CA offers multiple certificate chains, prefer
-                        the chain with an issuer matching this Subject Common
-                        Name. If no match, the default offered chain will be
-                        used. (default: None)
+                        the chain whose topmost certificate was issued from
+                        this Subject Common Name. If no match, the default
+                        offered chain will be used. (default: None)
   --preferred-challenges PREF_CHALLS
                         A sorted, comma delimited list of the preferred
                         challenge to use during authorization with the most
@@ -118,7 +118,7 @@ optional arguments:
                         case, and to know when to deprecate support for past
                         Python versions and flags. If you wish to hide this
                         information from the Let's Encrypt server, set this to
-                        "". (default: CertbotACMEClient/1.10.1
+                        "". (default: CertbotACMEClient/1.14.0
                         (certbot(-auto); OS_NAME OS_VERSION) Authenticator/XXX
                         Installer/YYY (SUBCOMMAND; flags: FLAGS)
                         Py/major.minor.patchlevel). The flags encoded in the
@@ -167,19 +167,6 @@ automation:
   --duplicate           Allow making a certificate lineage that duplicates an
                         existing one (both can be renewed in parallel)
                         (default: False)
-  --os-packages-only    (certbot-auto only) install OS package dependencies
-                        and then stop (default: False)
-  --no-self-upgrade     (certbot-auto only) prevent the certbot-auto script
-                        from upgrading itself to newer released versions
-                        (default: Upgrade automatically)
-  --no-bootstrap        (certbot-auto only) prevent the certbot-auto script
-                        from installing OS-level dependencies (default: Prompt
-                        to install OS-wide dependencies, but exit if the user
-                        says 'No')
-  --no-permissions-check
-                        (certbot-auto only) skip the check on the file system
-                        permissions of the certbot-auto script (default:
-                        False)
   -q, --quiet           Silence all output except errors. Useful for
                         automation via cron. Implies --non-interactive.
                         (default: False)
@@ -254,8 +241,8 @@ paths:
   Flags for changing execution paths & servers
 
   --cert-path CERT_PATH
-                        Path to where certificate is saved (with auth --csr),
-                        installed from, or revoked. (default: None)
+                        Path to where certificate is saved (with certonly
+                        --csr), installed from, or revoked (default: None)
   --key-path KEY_PATH   Path to private key for certificate installation or
                         revocation (if account key is missing) (default: None)
   --fullchain-path FULLCHAIN_PATH
@@ -539,8 +526,8 @@ dns-cloudxns:
                         CloudXNS credentials INI file. (default: None)
 
 dns-digitalocean:
-  Obtain certs using a DNS TXT record (if you are using DigitalOcean for
-  DNS).
+  Obtain certificates using a DNS TXT record (if you are using DigitalOcean
+  for DNS).
 
   --dns-digitalocean-propagation-seconds DNS_DIGITALOCEAN_PROPAGATION_SECONDS
                         The number of seconds to wait for DNS to propagate
@@ -601,7 +588,8 @@ dns-google:
                         therequired permissions.) (default: None)
 
 dns-linode:
-  Obtain certs using a DNS TXT record (if you are using Linode for DNS).
+  Obtain certificates using a DNS TXT record (if you are using Linode for
+  DNS).
 
   --dns-linode-propagation-seconds DNS_LINODE_PROPAGATION_SECONDS
                         The number of seconds to wait for DNS to propagate
diff --git a/certbot/docs/compatibility.rst b/certbot/docs/compatibility.rst
index a4f33c281..d94642ec6 100644
--- a/certbot/docs/compatibility.rst
+++ b/certbot/docs/compatibility.rst
@@ -21,9 +21,9 @@ may change at any time. The second is that Certbot's behavior should only be
 considered stable with certain files but not all. Files with which users should
 expect Certbot to maintain its current behavior with are:
 
-* ``/etc/letsencrypt/live/<domain>/{cert,chain,fullchain,privkey}.pem`` where
-  ``<domain>`` is the name given to ``--cert-name``. If ``--cert-name`` is not
-  set by the user, it is the first domain given to ``--domains``.
+* ``/etc/letsencrypt/live/$domain/{cert,chain,fullchain,privkey}.pem``, where
+  ``$domain`` is the certificate name (see :ref:`where-certs`
+  for more details)
 * :ref:`CLI configuration files <config-file>`
 * Hook directories in ``/etc/letsencrypt/renewal-hooks``
 
diff --git a/certbot/docs/conf.py b/certbot/docs/conf.py
index dbd4067d5..254bd3edd 100644
--- a/certbot/docs/conf.py
+++ b/certbot/docs/conf.py
@@ -95,7 +95,11 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = [
+    '_build',
+    'challenges.rst',
+    'ciphers.rst'
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
diff --git a/certbot/docs/contributing.rst b/certbot/docs/contributing.rst
index 4e2643d7c..94e35f1bf 100644
--- a/certbot/docs/contributing.rst
+++ b/certbot/docs/contributing.rst
@@ -56,18 +56,18 @@ Set up the Python virtual environment that will host your Certbot local instance
 .. code-block:: shell
 
    cd certbot
-   python tools/venv3.py
+   python tools/venv.py
 
 .. note:: You may need to repeat this when
   Certbot's dependencies change or when a new plugin is introduced.
 
 You can now run the copy of Certbot from git either by executing
-``venv3/bin/certbot``, or by activating the virtual environment. You can do the
+``venv/bin/certbot``, or by activating the virtual environment. You can do the
 latter by running:
 
 .. code-block:: shell
 
-   source venv3/bin/activate
+   source venv/bin/activate
 
 After running this command, ``certbot`` and development tools like ``ipdb``,
 ``ipython``, ``pytest``, and ``tox`` are available in the shell where you ran
@@ -169,7 +169,7 @@ To do so you need:
 - Docker installed, and a user with access to the Docker client,
 - an available `local copy`_ of Certbot.
 
-The virtual environment set up with `python tools/venv3.py` contains two CLI tools
+The virtual environment set up with `python tools/venv.py` contains two CLI tools
 that can be used once the virtual environment is activated:
 
 .. code-block:: shell
@@ -197,8 +197,8 @@ using an HTTP-01 challenge on a machine with Python 3:
 
 .. code-block:: shell
 
-    python tools/venv3.py
-    source venv3/bin/activate
+    python tools/venv.py
+    source venv/bin/activate
     run_acme_server &
     certbot_test certonly --standalone -d test.example.com
     # To stop Pebble, launch `fg` to get back the background job, then press CTRL+C
@@ -222,8 +222,6 @@ certbot-apache and certbot-nginx
   client code to configure specific web servers
 certbot-dns-*
   client code to configure DNS providers
-certbot-auto and letsencrypt-auto
-  shell scripts to install Certbot and its dependencies on UNIX systems
 windows installer
   Installs Certbot on Windows and is built using the files in windows-installer/
 
@@ -282,8 +280,8 @@ support for IIS, Icecast and Plesk.
 Installers and Authenticators will oftentimes be the same class/object
 (because for instance both tasks can be performed by a webserver like nginx)
 though this is not always the case (the standalone plugin is an authenticator
-that listens on port 80, but it cannot install certs; a postfix plugin would
-be an installer but not an authenticator).
+that listens on port 80, but it cannot install certificates; a postfix plugin
+would be an installer but not an authenticator).
 
 Installers and Authenticators are kept separate because
 it should be possible to use the `~.StandaloneAuthenticator` (it sets
@@ -470,24 +468,14 @@ Mypy type annotations
 =====================
 
 Certbot uses the `mypy`_ static type checker. Python 3 natively supports official type annotations,
-which can then be tested for consistency using mypy. Python 2 doesn’t, but type annotations can
-be `added in comments`_. Mypy does some type checks even without type annotations; we can find
-bugs in Certbot even without a fully annotated codebase.
-
-Certbot supports both Python 2 and 3, so we’re using Python 2-style annotations.
+which can then be tested for consistency using mypy. Mypy does some type checks even without type
+annotations; we can find bugs in Certbot even without a fully annotated codebase.
 
 Zulip wrote a `great guide`_ to using mypy. It’s useful, but you don’t have to read the whole thing
 to start contributing to Certbot.
 
 To run mypy on Certbot, use ``tox -e mypy`` on a machine that has Python 3 installed.
 
-Note that instead of just importing ``typing``, due to packaging issues, in Certbot we import from
-``acme.magic_typing`` and have to add some comments for pylint like this:
-
-.. code-block:: python
-
-  from acme.magic_typing import Dict
-
 Also note that OpenSSL, which we rely on, has type definitions for crypto but not SSL. We use both.
 Those imports should look like this:
 
@@ -558,53 +546,6 @@ Instructions for how to manually build and run the Certbot snap and the external
 snapped DNS plugins that the Certbot project supplies are located in the README
 file at https://github.com/certbot/certbot/tree/master/tools/snap.
 
-Updating certbot-auto and letsencrypt-auto
-==========================================
-
-.. note:: We are currently only accepting changes to certbot-auto that fix
-  regressions on platforms where certbot-auto is the recommended installation
-  method at https://certbot.eff.org/instructions. If you are unsure if a change
-  you want to make qualifies, don't hesitate to `ask for help`_!
-
-Updating the scripts
---------------------
-Developers should *not* modify the ``certbot-auto`` and ``letsencrypt-auto`` files
-in the root directory of the repository.  Rather, modify the
-``letsencrypt-auto.template`` and associated platform-specific shell scripts in
-the ``letsencrypt-auto-source`` and
-``letsencrypt-auto-source/pieces/bootstrappers`` directory, respectively.
-
-Building letsencrypt-auto-source/letsencrypt-auto
--------------------------------------------------
-Once changes to any of the aforementioned files have been made, the
-``letsencrypt-auto-source/letsencrypt-auto`` script should be updated.  In lieu of
-manually updating this script, run the build script, which lives at
-``letsencrypt-auto-source/build.py``:
-
-.. code-block:: shell
-
-   python letsencrypt-auto-source/build.py
-
-Running ``build.py`` will update the ``letsencrypt-auto-source/letsencrypt-auto``
-script.  Note that the ``certbot-auto`` and ``letsencrypt-auto`` scripts in the root
-directory of the repository will remain **unchanged** after this script is run.
-Your changes will be propagated to these files during the next release of
-Certbot.
-
-Opening a PR
-------------
-When opening a PR, ensure that the following files are committed:
-
-1. ``letsencrypt-auto-source/letsencrypt-auto.template`` and
-   ``letsencrypt-auto-source/pieces/bootstrappers/*``
-2. ``letsencrypt-auto-source/letsencrypt-auto`` (generated by ``build.py``)
-
-It might also be a good idea to double check that **no** changes were
-inadvertently made to the ``certbot-auto`` or ``letsencrypt-auto`` scripts in the
-root of the repository.  These scripts will be updated by the core developers
-during the next release.
-
-
 Updating the documentation
 ==========================
 
diff --git a/certbot/docs/install.rst b/certbot/docs/install.rst
index aefe1809e..99cf11c16 100644
--- a/certbot/docs/install.rst
+++ b/certbot/docs/install.rst
@@ -28,7 +28,7 @@ your system.
 System Requirements
 ===================
 
-Certbot currently requires Python 2.7 or 3.6+ running on a UNIX-like operating
+Certbot currently requires Python 3.6+ running on a UNIX-like operating
 system. By default, it requires root access in order to write to
 ``/etc/letsencrypt``, ``/var/log/letsencrypt``, ``/var/lib/letsencrypt``; to
 bind to port 80 (if you use the ``standalone`` plugin) and to read and
@@ -82,7 +82,7 @@ Docker if you are sure you know what you are doing and have a good reason to do
 so.
 
 You should definitely read the :ref:`where-certs` section, in order to
-know how to manage the certs
+know how to manage the certificates
 manually. `Our ciphersuites page <ciphers.html>`__
 provides some information about recommended ciphersuites. If none of
 these make much sense to you, you should definitely use the installation method
@@ -191,23 +191,23 @@ Optionally to install the Certbot Apache plugin, you can use:
 
 .. code-block:: shell
 
-   sudo apt-get install python-certbot-apache
+   sudo apt-get install python3-certbot-apache
 
 **Fedora**
 
 .. code-block:: shell
 
-    sudo dnf install certbot python2-certbot-apache
+    sudo dnf install certbot python3-certbot-apache
 
 **FreeBSD**
 
   * Port: ``cd /usr/ports/security/py-certbot && make install clean``
-  * Package: ``pkg install py27-certbot``
+  * Package: ``pkg install py37-certbot``
 
 **Gentoo**
 
-The official Certbot client is available in Gentoo Portage. From the 
-official Certbot plugins, three of them are also available in Portage. 
+The official Certbot client is available in Gentoo Portage. From the
+official Certbot plugins, three of them are also available in Portage.
 They need to be installed separately if you require their functionality.
 
 .. code-block:: shell
@@ -217,13 +217,13 @@ They need to be installed separately if you require their functionality.
    emerge -av app-crypt/certbot-nginx
    emerge -av app-crypt/certbot-dns-nsone
 
-.. Note:: The ``app-crypt/certbot-dns-nsone`` package has a different 
+.. Note:: The ``app-crypt/certbot-dns-nsone`` package has a different
    maintainer than the other packages and can lag behind in version.
 
 **NetBSD**
 
   * Build from source: ``cd /usr/pkgsrc/security/py-certbot && make install clean``
-  * Install pre-compiled package: ``pkg_add py27-certbot``
+  * Install pre-compiled package: ``pkg_add py37-certbot``
 
 **OpenBSD**
 
@@ -240,40 +240,21 @@ look at the :doc:`packaging`.
 
 Certbot-Auto
 ------------
+.. toctree::
+   :hidden:
+
+   uninstall
+
 
 We used to have a shell script named ``certbot-auto`` to help people install
 Certbot on UNIX operating systems, however, this script is no longer supported.
 If you want to uninstall ``certbot-auto``, you can follow our instructions
 :doc:`here <uninstall>`.
 
-Problems with Python virtual environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When using ``certbot-auto`` on a low memory system such as VPS with less than
-512MB of RAM, the required dependencies of Certbot may fail to build.  This can
-be identified if the pip outputs contains something like ``internal compiler
-error: Killed (program cc1)``.  You can workaround this restriction by creating
-a temporary swapfile::
-
-  user@webserver:~$ sudo fallocate -l 1G /tmp/swapfile
-  user@webserver:~$ sudo chmod 600 /tmp/swapfile
-  user@webserver:~$ sudo mkswap /tmp/swapfile
-  user@webserver:~$ sudo swapon /tmp/swapfile
-
-Disable and remove the swapfile once the virtual environment is constructed::
-
-  user@webserver:~$ sudo swapoff /tmp/swapfile
-  user@webserver:~$ sudo rm /tmp/swapfile
-
-Installing from source
-----------------------
-
-Installation from source is only supported for developers and the
-whole process is described in the :doc:`contributing`.
+Pip
+---
 
-.. warning:: Please do **not** use ``python certbot/setup.py install``, ``python pip
-   install certbot``, or ``easy_install certbot``. Please do **not** attempt the
-   installation commands as superuser/root and/or without virtual environment,
-   e.g. ``sudo python certbot/setup.py install``, ``sudo pip install``, ``sudo
-   ./venv/bin/...``. These modes of operation might corrupt your operating
-   system and are **not supported** by the Certbot team!
+Installing Certbot through pip is only supported on a best effort basis and
+when using a virtual environment. Instructions for installing Certbot through
+pip can be found at https://certbot.eff.org/instructions by selecting your
+server software and then choosing "pip" in the "System" dropdown menu.
diff --git a/certbot/docs/man/certbot.rst b/certbot/docs/man/certbot.rst
index d03f3eed4..2f25504b0 100644
--- a/certbot/docs/man/certbot.rst
+++ b/certbot/docs/man/certbot.rst
@@ -1 +1,3 @@
+:orphan:
+
 .. literalinclude:: ../cli-help.txt
diff --git a/certbot/docs/using.rst b/certbot/docs/using.rst
index 50f5b13fd..e38725ca3 100644
--- a/certbot/docs/using.rst
+++ b/certbot/docs/using.rst
@@ -14,7 +14,7 @@ obtaining, renewing, or revoking certificates. The most important
 and commonly-used commands will be discussed throughout this
 document; an exhaustive list also appears near the end of the document.
 
-The ``certbot`` script on your web server might be named ``letsencrypt`` if your system uses an older package, or ``certbot-auto`` if you used an alternate installation method. Throughout the docs, whenever you see ``certbot``, swap in the correct name as needed.
+The ``certbot`` script on your web server might be named ``letsencrypt`` if your system uses an older package, or ``certbot-auto`` if you used a now-deprecated installation method. Throughout the docs, whenever you see ``certbot``, swap in the correct name as needed.
 
 .. _plugins:
 
@@ -313,7 +313,7 @@ the ``certificates`` subcommand:
 
 This returns information in the following format::
 
-  Found the following certs:
+  Found the following certificates:
     Certificate Name: example.com
       Domains: example.com, www.example.com
       Expiry Date: 2017-02-19 19:53:00+00:00 (VALID: 30 days)
@@ -420,7 +420,7 @@ option to control the curve used in ECDSA certificates.
 .. warning:: If you obtain certificates using ECDSA keys, you should be careful
    not to downgrade your Certbot installation since ECDSA keys are not
    supported by older versions of Certbot. Downgrades like this are possible if
-   you switch from something like the snaps or certbot-auto to packages
+   you switch from something like the snaps or pip to packages
    provided by your operating system which often lag behind.
 
 Changing existing certificates from RSA to ECDSA
@@ -474,29 +474,37 @@ like
 Revoking certificates
 ---------------------
 
-If your account key has been compromised or you otherwise need to revoke a certificate,
-use the ``revoke`` command to do so. Note that the ``revoke`` command takes the certificate path
-(ending in ``cert.pem``), not a certificate name or domain. Example::
+If you need to revoke a certificate, use the ``revoke`` subcommand to do so.
 
-  certbot revoke --cert-path /etc/letsencrypt/live/CERTNAME/cert.pem
+A certificate may be revoked by providing its name (see ``certbot certificates``) or by providing
+its path directly::
+
+  certbot revoke --cert-name example.com
+
+  certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem
+
+If the certificate being revoked was obtained via the ``--staging``, ``--test-cert`` or a non-default ``--server`` flag,
+that flag must be passed to the ``revoke`` subcommand.
+
+.. note:: After revocation, Certbot will (by default) ask whether you want to **delete** the certificate.
+          Unless deleted, Certbot will try to renew revoked certificates the next time ``certbot renew`` runs.
 
 You can also specify the reason for revoking your certificate by using the ``reason`` flag.
 Reasons include ``unspecified`` which is the default, as well as ``keycompromise``,
 ``affiliationchanged``, ``superseded``, and ``cessationofoperation``::
 
-  certbot revoke --cert-path /etc/letsencrypt/live/CERTNAME/cert.pem --reason keycompromise
+  certbot revoke --cert-name example.com --reason keycompromise
 
-Additionally, if a certificate
-is a test certificate obtained via the ``--staging`` or ``--test-cert`` flag, that flag must be passed to the
-``revoke`` subcommand.
-Once a certificate is revoked (or for other certificate management tasks), all of a certificate's
-relevant files can be removed from the system with the ``delete`` subcommand::
+Revoking by account key or certificate private key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  certbot delete --cert-name example.com
+By default, Certbot will try revoke the certificate using your ACME account key. If the certificate was created from
+the same ACME account, the revocation will be successful.
 
-.. note:: If you don't use ``delete`` to remove the certificate completely, it will be renewed automatically at the next renewal event.
+If you instead have the corresponding private key file to the certificate you wish to revoke, use ``--key-path`` to perform the
+revocation from any ACME account::
 
-.. note:: Revoking a certificate will have no effect on the rate limit imposed by the Let's Encrypt server.
+  certbot revoke --cert-path /etc/letsencrypt/live/example.com/cert.pem --key-path /etc/letsencrypt/live/example.com/privkey.pem
 
 .. _renewal:
 
@@ -507,11 +515,8 @@ Renewing certificates
    days). Make sure you renew the certificates at least once in 3
    months.
 
-.. seealso:: Many of the certbot clients obtained through a
-   distribution come with automatic renewal out of the box,
-   such as Debian and Ubuntu versions installed through `apt`,
-   CentOS/RHEL 7 through EPEL, etc.  See `Automated Renewals`_
-   for more details.
+.. seealso:: Most Certbot installations come with automatic
+   renewal out of the box. See `Automated Renewals`_ for more details.
 
 As of version 0.10.0, Certbot supports a ``renew`` action to check
 all installed certificates for impending expiry and attempt to renew
@@ -681,27 +686,15 @@ The following commands could be used to specify where these files are located::
 Automated Renewals
 ------------------
 
-Many Linux distributions provide automated renewal when you use the
-packages installed through their system package manager.  The
-following table is an *incomplete* list of distributions which do so,
-as well as their methods for doing so.
-
-If you are not sure whether or not your system has this already
-automated, refer to your distribution's documentation, or check your
-system's crontab (typically in `/etc/crontab/` and `/etc/cron.*/*` and
-systemd timers (`systemctl list-timers`).
+Most Certbot installations come with automatic renewals preconfigured. This
+is done by means of a scheduled task which runs ``certbot renew`` periodically.
 
-.. csv-table:: Distributions with Automated Renewal
-   :header: "Distribution Name", "Distribution Version", "Automation Method"
+If you are unsure whether you need to configure automated renewal:
 
-   "CentOS", "EPEL 7", "systemd"
-   "Debian", "stretch", "cron, systemd"
-   "Debian", "testing/sid", "cron, systemd"
-   "Fedora", "26", "systemd"
-   "Fedora", "27", "systemd"
-   "RHEL", "EPEL 7", "systemd"
-   "Ubuntu", "17.10", "cron, systemd"
-   "Ubuntu", "certbot PPA", "cron, systemd"
+1. Review the instructions for your system at https://certbot.eff.org/instructions.
+   They will describe how to set up a scheduled task, if necessary.
+2. (Linux/BSD): Check your system's crontab (typically `/etc/crontab` and
+   `/etc/cron.*/*`) and systemd timers (``systemctl list-timers``).
 
 .. _where-certs:
 
@@ -709,12 +702,24 @@ Where are my certificates?
 ==========================
 
 All generated keys and issued certificates can be found in
-``/etc/letsencrypt/live/$domain``. In the case of creating a SAN certificate
-with multiple alternative names, ``$domain`` is the first domain passed in
-via -d parameter. Rather than copying, please point
-your (web) server configuration directly to those files (or create
-symlinks). During the renewal_, ``/etc/letsencrypt/live`` is updated
-with the latest necessary files.
+``/etc/letsencrypt/live/$domain``, where ``$domain`` is the certificate
+name (see the note below). Rather than copying, please point your (web)
+server configuration directly to those files (or create symlinks).
+During the renewal_, ``/etc/letsencrypt/live`` is updated with the latest
+necessary files.
+
+.. note::
+  The certificate name ``$domain`` used in the path ``/etc/letsencrypt/live/$domain``
+  follows this convention:
+
+  * it is the name given to ``--cert-name``,
+  * if ``--cert-name`` is not set by the user it is the first domain given to
+    ``--domains``,
+  * if the first domain is a wildcard domain (eg. ``*.example.com``) the
+    certificate name will be ``example.com``,
+  * if a name collision would occur with a certificate already named ``example.com``,
+    the new certificate name will be constructed using a numerical sequence
+    as ``example.com-001``.
 
 For historical reasons, the containing directories are created with
 permissions of ``0700`` meaning that certificates are accessible only
@@ -912,7 +917,7 @@ Changing the ACME Server
 ========================
 
 By default, Certbot uses Let's Encrypt's production server at
-https://acme-v02.api.letsencrypt.org/. You can tell Certbot to use a
+https://acme-v02.api.letsencrypt.org/directory. You can tell Certbot to use a
 different CA by providing ``--server`` on the command line or in a
 :ref:`configuration file <config-file>` with the URL of the server's
 ACME directory. For example, if you would like to use Let's Encrypt's
```