### PR TITLE
Remove custom sphinx theme

### DIFF
--- a/_docs.sh
+++ b/_docs.sh
@@ -12,7 +12,6 @@ case "$1" in
   "install" )
     cd _docs
     source ./venv/bin/activate
-    pip install --upgrade git+https://github.com/EFForg/sphinx_rtd_theme.git
     cd certbot
     make -C docs clean html epub latex latexpdf > /dev/null
     ;;


### PR DESCRIPTION
Fixes https://github.com/certbot/website/issues/711.

Removing this theme was originally suggested in https://github.com/EFForg/sphinx_rtd_theme/pull/6. Looking at https://github.com/EFForg/sphinx_rtd_theme/compare/eeff564...master, it seems the main changes made in our fork were to add analytics, a navigation bar at the top, and tweak things like the font/colors to better match the added navigation bar and the rest of the Certbot site. I don't think it's worth continuing to maintain this fork for these reasons though. I think the default readthedocs theme is sufficient and its much easier for us to maintain.

With the non-forked theme, the docs look like:
![Screen Shot 2021-05-19 at 4 00 20 PM](https://user-images.githubusercontent.com/6504915/118895642-62bed200-b8bb-11eb-8a11-6503a3add534.png)
