### PR TITLE
Pin back npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc && \
 RUN apt-get install -y npm
 RUN npm install -g n
 RUN n 8.12.0
-RUN npm install -g npm gulp-cli
+RUN npm install -g npm@"<7" gulp-cli
 
 # Install Javascript packages
 COPY package.json ./


### PR DESCRIPTION
Running a command like `docker-compose build --no-cache site` fails for me. The output is:
```
 => ERROR [12/17] RUN npm install                                                                                                                                                                                                                                                                                      3.3s
------                                                                                                                                                                                                                                                                                                                      
 > [12/17] RUN npm install:                                                                                                                                                                                                                                                                                                 
#16 0.586 npm WARN npm npm does not support Node.js v8.12.0                                                                                                                                                                                                                                                                 
#16 0.591 npm WARN npm You should probably upgrade to a newer version of node as we                                                                                                                                                                                                                                         
#16 0.593 npm WARN npm can't make any promises that npm will work with this version.                                                                                                                                                                                                                                        
#16 0.594 npm WARN npm You can find the latest version at https://nodejs.org/
#16 3.190 npm ERR! URL is not defined
#16 3.208 
#16 3.209 npm ERR! A complete log of this run can be found in:
#16 3.209 npm ERR!     /root/.npm/_logs/2021-05-20T19_19_22_050Z-debug.log
------
executor failed running [/bin/sh -c npm install]: exit code: 1
ERROR: Service 'site' failed to build
```
Pinning back `npm` fixes the problem for me. I think it'd be better to upgrade to a newer version of node, however, this approach seems much easier and I think is fine when node/npm are just used to build the site.