### PR TITLE
Update to Node.js 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,14 @@ RUN echo 'gem: --no-document' >> /usr/local/etc/gemrc && \
     gem install jekyll html-proofer
 
 # Install node and dependencies
-RUN apt-get install -y npm
-RUN npm install -g n
-RUN n 8.12.0
-RUN npm install -g npm gulp-cli
+RUN curl -fsSL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install -g gulp-cli
 
 # Install Javascript packages
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install
+RUN npm ci
 
 # Install docs dependencies
 COPY _docs.sh ./


### PR DESCRIPTION
Using the official way proposed to install Node.js on debian/ubuntu systems (https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions), this PR upgrades the build Docker to Node.js 10.

I checked that this version is working with the current set of dependencies (note that Node.js 12 is not).