### PR TITLE
Improve renewal instructions in the instruction generator

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -6,6 +6,7 @@
   automatically before they expire. You will not need to run Certbot again, unless you change your
   configuration. You can test automatic renewal for your certificates by running this command:
   <pre>sudo {{base_command}} renew --dry-run</pre>
+  If that command completes without errors, your certificates will renew automatically in the background.
   </p>
 
 {{/cron_included}}

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -8,15 +8,6 @@
   <pre>sudo {{base_command}} renew --dry-run</pre>
   </p>
 
-  <p>
-  The command to renew certbot is installed in one of the following locations:
-  <ul>
-    <li><tt>/etc/crontab/</tt></li>
-    <li><tt>/etc/cron.*/*</tt></li>
-    <li><tt>systemctl list-timers</tt></li>
-  </ul>
-  </p>
-
   {{#certonly}}
   <p>
   If you needed to stop your webserver to run Certbot, you'll want to add hook

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -5,7 +5,8 @@
   The Certbot packages on your system come with a cron job or systemd timer that will renew your certificates
   automatically before they expire. You will not need to run Certbot again, unless you change your
   configuration. You can test automatic renewal for your certificates by running this command:
-  <pre>sudo {{base_command}} renew --dry-run</pre>
+  <pre>sudo {{base_command}} renew --dry-run</pre></p>
+  <p>
   If that command completes without errors, your certificates will renew automatically in the background.
   </p>
 

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -1,5 +1,5 @@
-{{#cron_included}}
 <li>
+{{#cron_included}}
   Test automatic renewal
   <p>
   The Certbot packages on your system come with a cron job or systemd timer that will renew your certificates
@@ -8,11 +8,22 @@
   <pre>sudo {{base_command}} renew --dry-run</pre>
   </p>
 
+{{/cron_included}}
+{{^cron_included}}
+  Set up automatic renewal
+  <p>
+  Run the following line, which will add a cron job to <code>/etc/crontab</code>.
+  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew -q" | sudo tee -a /etc/crontab > /dev/null</pre>
+  </p>
+
+{{/cron_included}}
+
   {{#certonly}}
   <p>
-  If you needed to stop your webserver to run Certbot, you'll want to add hook
-  scripts to stop and start your webserver automatically. For example, if your
-  webserver is HAProxy, run the following commands:
+  If you needed to stop your webserver to run Certbot, you'll want to
+  add <code>pre</code> and <code>post</code> hooks to stop and start your webserver automatically.
+  For example, if your webserver is HAProxy, run the following commands to create the hook files
+  in the appropriate directory:
   </p>
 
   <pre class="no-before"><ol><li>sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'</li>
@@ -28,34 +39,6 @@
   {{/certonly}}
 
 </li>
-{{/cron_included}}
-{{^cron_included}}
-
-<li>
-  Set up automatic renewal
-  <p>
-  We recommend running the following line, which will add a cron job to the default crontab.
-  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew -q" | sudo tee -a /etc/crontab > /dev/null</pre>
-  </p>
-
-  {{#certonly}}
-  <p>
-  If you needed to stop your webserver to run Certbot, you'll want to
-  add <tt>--pre-hook</tt> and <tt>--post-hook</tt> flags after <tt>{{base_command}} renew</tt> to stop
-  and start your webserver automatically. For example, if your webserver is HAProxy, modify the
-  command as follows:
-
-  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew -q --pre-hook 'service haproxy stop' --post-hook 'service haproxy start'" | sudo tee -a /etc/crontab > /dev/null</pre>
-  </p>
-
-  <p>
-  More information is available in the
-  <a href='/docs/using.html?highlight=hooks#renewing-certificates'>
-  Certbot documentation on renewing certificates</a>.
-  </p>
-  {{/certonly}}
-</li>
-{{/cron_included}}
 
 <li>
   Confirm that Certbot worked


### PR DESCRIPTION
These changes are done to match our updated [cli ux](https://github.com/certbot/certbot/pull/8860), our updated [docs instructions](https://github.com/certbot/certbot/pull/8870), and feedback from the CISPA Usable Security group. 

pip apache (cron not included, no certonly)
![pip-apache](https://user-images.githubusercontent.com/1227205/119911655-9084c600-bf0e-11eb-89bf-54cf16675686.png)

pip other (cron not included, certonly)
![pip-other](https://user-images.githubusercontent.com/1227205/119911659-937fb680-bf0e-11eb-9647-62209d7ce15f.png)

snapd apache (cron included, no certonly)
![ubuntu-no-certonly](https://user-images.githubusercontent.com/1227205/119912220-dd1cd100-bf0f-11eb-90da-39384db11b30.png)

snapd other (cron included, certonly)
![snapd-certonly](https://user-images.githubusercontent.com/1227205/119912218-db530d80-bf0f-11eb-8d6e-9967fe5bdc40.png)


This PR does not include the Windows instructions, which are hard-coded on their own in `windows.html`.