### PR TITLE
Give both cron-included and non-cron-included users instructions on how to test using --dry-run

### DIFF
--- a/_scripts/instruction-widget/get-started.js
+++ b/_scripts/instruction-widget/get-started.js
@@ -44,6 +44,7 @@ module.exports = function(context) {
         context.imperative = "you should probably"
         template = "haproxy";
         context.certonly = true;
+        context.haproxy = true;
     }
 
     plesk_getting_started = function() {

--- a/_scripts/instruction-widget/get-started.js
+++ b/_scripts/instruction-widget/get-started.js
@@ -43,6 +43,7 @@ module.exports = function(context) {
         context.officially = "officially ";
         context.imperative = "you should probably"
         template = "haproxy";
+        context.certonly = true;
     }
 
     plesk_getting_started = function() {

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -17,12 +17,22 @@
 {{/cron_included}}
 
   {{#certonly}}
+  {{#haproxy}}
+  <p>
+  Next, you'll want to add <code>pre</code> and <code>post</code> hooks to stop and start your
+  webserver automatically. Run the following commands to create the hook files in the appropriate
+  directory:
+  </p>
+  {{/haproxy}}
+  {{^haproxy}}
   <p>
   If you needed to stop your webserver to run Certbot, you'll want to
   add <code>pre</code> and <code>post</code> hooks to stop and start your webserver automatically.
   For example, if your webserver is HAProxy, run the following commands to create the hook files
   in the appropriate directory:
   </p>
+  {{/haproxy}}
+
 
   <pre class="no-before"><ol><li>sudo sh -c 'printf "#!/bin/sh\nservice haproxy stop\n" > /etc/letsencrypt/renewal-hooks/pre/haproxy.sh'</li>
     <li>sudo sh -c 'printf "#!/bin/sh\nservice haproxy start\n" > /etc/letsencrypt/renewal-hooks/post/haproxy.sh'</li>

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -4,11 +4,7 @@
   <p>
   The Certbot packages on your system come with a cron job or systemd timer that will renew your certificates
   automatically before they expire. You will not need to run Certbot again, unless you change your
-  configuration. You can test automatic renewal for your certificates by running this command:
-  <pre>sudo {{base_command}} renew --dry-run</pre></p>
-  <p>
-  If that command completes without errors, your certificates will renew automatically in the background.
-  </p>
+  configuration.</p>
 
 {{/cron_included}}
 {{^cron_included}}
@@ -39,6 +35,12 @@
   Certbot documentation on renewing certificates</a>.
   </p>
   {{/certonly}}
+
+  <p>You can test automatic renewal for your certificates by running this command:
+  <pre>sudo {{base_command}} renew --dry-run</pre></p>
+  <p>
+  If that command completes without errors, your certificates will renew automatically in the background.
+  </p>
 
 </li>
 


### PR DESCRIPTION
As pointed out [here](https://github.com/certbot/website/pull/716#pullrequestreview-670978337), we weren't showing users who needed to set up automatic renewal how to test their renewal setup. We should do that. Also, now that we always have users use directory hooks, we should have them test after they've set up the hooks.

Snap, apache (no certonly)
![snap-apache2](https://user-images.githubusercontent.com/1227205/120043525-f7fb4e00-bfc0-11eb-84a1-e628b4db0d41.png)

Snap, none of the above (certonly)
![snap-other2](https://user-images.githubusercontent.com/1227205/120043527-f893e480-bfc0-11eb-87cb-c4619a087e65.png)

Snap, haproxy (certonly)
![snap-haproxy](https://user-images.githubusercontent.com/1227205/120403481-22b71080-c2f9-11eb-91b3-3ec3327f3ef6.png)

Pip, apache (no certonly)
![Screenshot from 2021-05-28 14-26-59](https://user-images.githubusercontent.com/1227205/120043530-f92c7b00-bfc0-11eb-9dd7-a4339e77bd32.png)

Pip, none of the above (certonly)
![none-of-the-above](https://user-images.githubusercontent.com/1227205/120403511-2c407880-c2f9-11eb-8c07-24d0085c8add.png)

Pip, haproxy (certonly)
![Screenshot from 2021-06-01 16-46-23](https://user-images.githubusercontent.com/1227205/120403532-3793a400-c2f9-11eb-8592-b7efaa1ec3d7.png)
