### PR TITLE
Change openSUSE Leap dropdown version to 15.x

### DIFF
--- a/_data/inputs.json
+++ b/_data/inputs.json
@@ -165,10 +165,10 @@
           "version": "0"
         },
         {
-          "name": "openSUSE Leap 15.0",
+          "name": "openSUSE Leap 15.x",
           "id": "leap",
           "distro": "opensuse",
-          "version": "15.0"
+          "version": "15"
         },
         {
             "name": "Other Linux (snapd)",


### PR DESCRIPTION
15.0 has reached its EOL, but there are still other openSUSE Leap 15 versions so let's use a more generic version number here. More info about openSUSE's versions can be found at https://en.wikipedia.org/wiki/OpenSUSE_version_history#Version_history and this suggestion came from https://github.com/certbot/website/issues/721.

A screenshot with this change is:
![Screen Shot 2021-06-11 at 9 42 57 AM](https://user-images.githubusercontent.com/6504915/121722189-f8ecaf00-ca99-11eb-9173-42e85922f210.png)