### PR TITLE
windows: use net.exe rather than net

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -94,7 +94,7 @@ able to use to obtain a certificate from Let's Encrypt.
 
 <p>If you needed to stop your webserver to run Certbot (for example, if you used the standalone authenticator on a machine where port 80 is normally in use), you'll want to edit the built-in command to add the <code>--pre-hook</code> and <code>--post-hook</code> flags to stop and start your webserver automatically. For example, if your webserver is Apache 2.4, add the following to the certbot renew command:</p>
 
-<p><code>--pre-hook &quot;net stop Apache2.4&quot; --post-hook &quot;net start Apache2.4&quot;</code></p>
+<p><code>--pre-hook &quot;net.exe stop Apache2.4&quot; --post-hook &quot;net.exe start Apache2.4&quot;</code></p>
 
 <p>More information is available in the <em>Certbot documentation on renewing certificates.</em></p>
 </li>


### PR DESCRIPTION
To work around certbot/certbot#8215.

----

There is a related issue (#720) to rewrite this section, but I'd rather just ship this now so users don't keep hitting it.

![image](https://user-images.githubusercontent.com/311534/122699464-d1ad9300-d28c-11eb-8e07-3d4c4c673d8b.png)
