### PR TITLE
pip: remove the snap in addition to OS packages

### DIFF
--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -45,7 +45,7 @@
     Remove certbot-auto and any other Certbot packages
     <p>
     If you have installed Certbot packages from any other sources like <code>apt</code>,
-    <code>yum</code>, <code>dnf</code> or <code>snapd</code>, you should remove them before
+    <code>yum</code>, <code>dnf</code>, or <code>snapd</code>, you should remove them before
     installing Certbot with <code>pip</code>. This is to ensure that when you run the command
     <code>certbot</code>, Certbot from <code>pip</code> is used rather than from the other
     package managers. The exact command to do this depends on your OS, but common examples are
@@ -80,4 +80,3 @@
 {{/advanced}}
 
 {{> dnspluginssetup}}
-

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -50,7 +50,7 @@
     <code>certbot</code>, Certbot from <code>pip</code> is used rather than from the other
     package managers. The exact command to do this depends on your OS, but common examples are
     <code>sudo apt-get remove certbot</code>, <code>sudo yum remove certbot</code>,
-    <code>sudo dnf remove certbot</code> or <code>sudo snap remove certbot</code>.
+    <code>sudo dnf remove certbot</code>, or <code>sudo snap remove certbot</code>.
     </p>
     <p>
     If you previously used Certbot through the certbot-auto script, you should

--- a/_scripts/instruction-widget/templates/install/pip.html
+++ b/_scripts/instruction-widget/templates/install/pip.html
@@ -42,15 +42,15 @@
     "augeas on &lt;your_system_name&gt;" will probably yield helpful results.</p>
 </li>
 <li>
-    Remove certbot-auto and any Certbot OS packages
+    Remove certbot-auto and any other Certbot packages
     <p>
-    If you have any Certbot packages installed using an OS package manager like
-    <code>apt</code>, <code>dnf</code>, or <code>yum</code>, you should remove them before
-    installing the Certbot snap to ensure that when you run the command
-    <code>certbot</code> the snap is used rather than the installation from your OS
-    package manager. The exact command to do this depends on your OS, but
-    common examples are <code>sudo apt-get remove certbot</code>, <code>sudo dnf
-    remove certbot</code>, or <code>sudo yum remove certbot</code>.
+    If you have installed Certbot packages from any other sources like <code>apt</code>,
+    <code>yum</code>, <code>dnf</code> or <code>snapd</code>, you should remove them before
+    installing Certbot with <code>pip</code>. This is to ensure that when you run the command
+    <code>certbot</code>, Certbot from <code>pip</code> is used rather than from the other
+    package managers. The exact command to do this depends on your OS, but common examples are
+    <code>sudo apt-get remove certbot</code>, <code>sudo yum remove certbot</code>,
+    <code>sudo dnf remove certbot</code> or <code>sudo snap remove certbot</code>.
     </p>
     <p>
     If you previously used Certbot through the certbot-auto script, you should


### PR DESCRIPTION
Some minor edits to the instructions to:

- Ask the user to remove the Certbot snap in addition to OS packages and certbot-auto
- Remove some irrelevant copy ("... before installing the Certbot snap ...") which was copy-pasted from the snapd instructions.

This [came up](https://community.letsencrypt.org/t/error-access-denied-to-install-certbot-dns-cloudflare/156775/10?u=_az) on the forums. I guess some users will move from `snapd` to `pip` on occasion. It especially makes sense if they want a third-party plugin which isn't snapped.

![image](https://user-images.githubusercontent.com/311534/127611336-2d31ece6-7768-4b11-8c35-b4fdffda479c.png)
