### PR TITLE
macos: use $(command -v certbot) for cron

### DIFF
--- a/_scripts/instruction-widget/install.js
+++ b/_scripts/instruction-widget/install.js
@@ -234,6 +234,7 @@ module.exports = function(context) {
     template = "macos";
     context.base_command = "certbot";
     context.install_command = "brew install";
+    context.cron_base_command = "$(command -v certbot)";
   }
 
   // This function is currently unused, but we keep it around to make it easy

--- a/_scripts/instruction-widget/templates/getting-started/renewal.html
+++ b/_scripts/instruction-widget/templates/getting-started/renewal.html
@@ -11,7 +11,7 @@
   Set up automatic renewal
   <p>
   Run the following line, which will add a cron job to <code>/etc/crontab</code>.
-  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{base_command}} renew -q" | sudo tee -a /etc/crontab > /dev/null</pre>
+  <pre class="one-line">echo "0 0,12 * * * root {{python_name}} -c 'import random; import time; time.sleep(random.random() * 3600)' &amp;&amp; {{#cron_base_command}}{{cron_base_command}}{{/cron_base_command}}{{^cron_base_command}}{{base_command}}{{/cron_base_command}} renew -q" | sudo tee -a /etc/crontab > /dev/null</pre>
   </p>
 
 {{/cron_included}}


### PR DESCRIPTION
Certbot is not in the PATH when installed from Homebrew.

---

Per https://github.com/certbot/certbot/issues/8974.

Excuse the templating. I couldn't work out a way to do this in the "controller" without refactoring a bunch of other stuff. Any bright ideas on not having this be so hacky would be appreciated.

After this change, the macOS command becomes:

    echo "0 0,12 * * * root python -c 'import random; import time; time.sleep(random.random() * 3600)' && $(command -v certbot) renew -q" | sudo tee -a /etc/crontab > /dev/null

and the Linux (e.g. `pip`) command remains as:

    echo "0 0,12 * * * root /opt/certbot/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q" | sudo tee -a /etc/crontab > /dev/null