### PR TITLE
Fix Mattermost notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
+          cat mattermost.json
         if: ${{ failure() }}
           #- uses: mattermost/action-mattermost-notify@master
           #  env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
+          geqhgjkeqgheq
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1
@@ -45,9 +46,10 @@ jobs:
         run: ./push-build.sh
       - name: Write Mattermost Message
         run: |
-          echo "{\"text\":\"** :warning: certbot/website: Build failed :warning: ** | [(see details)]($GITHUB_WORKFLOW_URL) \"}" > mattermost.json
+          WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
         if: ${{ failure() }}
-      - uses: mattermost/action-mattermost-notify@master
-        env:
-          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-        if: ${{ failure() }}
+          #- uses: mattermost/action-mattermost-notify@master
+          #  env:
+          #    MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          #  if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
+          geqgeqgqe
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
-          gegqgfeq
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1
@@ -55,7 +54,6 @@ jobs:
         run: |
           WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
-          cat mattermost.josn
       - uses: mattermost/action-mattermost-notify@master
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,15 @@ jobs:
           CERTBOTBOT_SSH_KEY: ${{ secrets.CERTBOTBOT_SSH_KEY }}
         if: ${{ github.event_name != 'pull_request' }}
         run: ./push-build.sh
+  notify:
+    if: ${{ failure() && github.event_name != 'pull_request' }}
+    needs: ci
+    runs-on: ubuntu-20.04
+    steps:
       - name: Write Mattermost Message
         run: |
           WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
-        if: ${{ failure() }}
       - uses: mattermost/action-mattermost-notify@master
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-        if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
-          geqhgjkeqgheq
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1
@@ -48,9 +47,8 @@ jobs:
         run: |
           WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
-          cat mattermost.json
         if: ${{ failure() }}
-          #- uses: mattermost/action-mattermost-notify@master
-          #  env:
-          #    MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
-          #  if: ${{ failure() }}
+      - uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,9 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         run: ./push-build.sh
   notify:
-    if: ${{ failure() && github.event_name != 'pull_request' }}
+    # Only notify about failed builds, do not notify about failed builds for
+    # PRs, and only notify about failed pushes to master.
+    if: ${{ failure() && github.event_name != 'pull_request' && (github.event_name != 'push' || github.ref == 'refs/heads/master') }}
     needs: ci
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
-          geqgeqgqe
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           submodules: true
       - name: Install OS packages
         run: |
+          gegqgfeq
           sudo apt-get update
           sudo apt-get install gsfonts imagemagick latexmk texlive texlive-latex-extra -y
       - uses: ruby/setup-ruby@v1
@@ -52,6 +53,7 @@ jobs:
         run: |
           WORKFLOW_RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           echo "{\"text\":\"** :warning: $GITHUB_REPOSITORY: Build failed :warning: ** | [(see details)]($WORKFLOW_RUN_URL) \"}" > mattermost.json
+          cat mattermost.josn
       - uses: mattermost/action-mattermost-notify@master
         env:
           MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
This PR fixes a couple things:

1. `GITHUB_WORKFLOW_URL` is not a valid environment variable. The new approach creates a valid URL which you can see [here](https://github.com/certbot/website/runs/3488055196?check_suite_focus=true#step:3:9).
2. The previous code would also [report errors on pull requests not from forks](https://github.com/certbot/website/runs/3487706069?check_suite_focus=true) and pushes to non-master branches. You can see notifications being skipped on a non-master branch [here](https://github.com/certbot/website/actions/runs/1191396526) and being posted when the conditional is modified so the branch name matches [here](https://github.com/certbot/website/actions/runs/1191405565).