### PR TITLE
windows: link to alternative clients is outdated

### DIFF
--- a/_scripts/instruction-widget/templates/getting-started/windows.html
+++ b/_scripts/instruction-widget/templates/getting-started/windows.html
@@ -6,7 +6,7 @@
 <p>
 Certbot is now officially available for Windows. If you find that Certbot is not
 the most suitable Let's Encrypt client application for your use case, there are
-many <a href="https://community.letsencrypt.org/t/list-of-client-implementations/2103">
+many <a href="https://letsencrypt.org/docs/client-options/">
 other clients</a> written by other organizations and developers that you may be
 able to use to obtain a certificate from Let's Encrypt.
 </p>


### PR DESCRIPTION
The current link to alternative clients is to a community discussion that's not maintained. This change updates the link to point to a maintained document.

The alternative would be to remove the link.