### PR TITLE
ci: only run on 'push' for the master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: Certbot website CI
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     # Run at 4pm UTC or 9am PST


### PR DESCRIPTION
In https://github.com/certbot/website/pull/739, it looks like the CI tried to push a website build (which thankfully failed due to a missing secret).

It turns out the `push` event is triggered for any branch, not just the default branch. When @dependabot pushed to the https://github.com/certbot/website/tree/dependabot/npm_and_yarn%2Fdatatables.net-1.11.3 branch, the "Push build" part of the workflow was triggered.

This change limits the `push` event to the `master` branch only. It shouldn't affect PRs because supposedly the `pull_request:synchronize` event will be re-triggered every time there are new commits in the PR's source branch.