### PR TITLE
Don't build on dependabot branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         # and
         # https://github.com/certbot/website/blob/master/README.md#building-with-github-actions
         # for more info.
-        if: ${{ github.event_name != 'pull_request' && github.actor != "dependabot[bot]" }}
+        if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
         run: ./push-build.sh
   notify:
     # Only notify about failed builds, do not notify about failed builds for

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,19 @@ jobs:
       - name: Push build
         env:
           CERTBOTBOT_SSH_KEY: ${{ secrets.CERTBOTBOT_SSH_KEY }}
-        if: ${{ github.event_name != 'pull_request' }}
+        # This step cannot run successfully on branches created by dependabot
+        # because it won't have access to secrets due to
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/.
+        # We check for github.actor here because it skips running on branches
+        # when the build is triggered by dependabot, but it allows humans to
+        # manually retrigger the build which will give the build access to
+        # secrets. This is useful because it allows the built site to be pushed
+        # to the website-builds repo for easier review. See
+        # https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544
+        # and
+        # https://github.com/certbot/website/blob/master/README.md#building-with-github-actions
+        # for more info.
+        if: ${{ github.event_name != 'pull_request' && github.actor != "dependabot[bot]" }}
         run: ./push-build.sh
   notify:
     # Only notify about failed builds, do not notify about failed builds for


### PR DESCRIPTION
This is an alternate to https://github.com/certbot/website/pull/741.

This approach seems to work as described in the comment I wrote in YAML as I manually reran the build at https://github.com/certbot/website/pull/739/checks?check_run_id=3769087220 and it passed.