### PR TITLE
Fix #757 Install tex-gyre to for tgtermes.sty to be present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN ./_docs.sh depend
 
 COPY . .
 
+RUN apt-get install -y tex-gyre
+
 RUN gulp build
 
 CMD ["gulp", "jekyll:watch"]


### PR DESCRIPTION
This fixes pdflatex failing because of the missing input file tgtermes.sty.
See error in #754

This might not be the correct place to place the installer.