### PR TITLE
Added viridio.net to hosting providers list.

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -3,9 +3,9 @@
     "name": "Viridio.net",
     "link": "https://viridio.net",
     "category": "partial",
-    "tutorial": "",
+    "tutorial": "https://viridio.net/ssl-certificates/",
     "announcement": "",
-    "plan": "https://viridio.net/ssl-certificates/",
+    "plan": "",
     "reviewed": "2023.11.18",
     "note": "Formerly AISO.net. Free Let's Encrypt SSL certificates, confusing interface."
   },

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1,5 +1,15 @@
 [
   {
+    "name": "Viridio.net",
+    "link": "https://viridio.net",
+    "category": "partial",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "https://viridio.net/ssl-certificates/",
+    "reviewed": "2023.11.18",
+    "note": "Formerly AISO.net. Free Let's Encrypt SSL certificates, confusing interface."
+  },
+  {
     "name": "Avantiv",
     "link": "https://avantiv.com",
     "category": "full",


### PR DESCRIPTION
Added viridio.net (formerly aiso.net) as a free Let's Encrypt hosting provider.  Confusing tutorial because it's a confusing interface.