### PR TITLE
Remove Hartserver from hosting providers

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2620,16 +2620,6 @@
     "note": "All plans come with Free Let's Encrypt automatically installed for Website and Mail"
   },
   {
-    "name": "Hartserver",
-    "link": "https://hartserver.net/",
-    "category": "full",
-    "tutorial": "",
-    "announcement": "https://twitter.com/hartserver/status/988699270780981248",
-    "plan": "",
-    "reviewed": "2021.10.08",
-    "note": "All free and paid hosting plans get Let's Encrypt certificates automatically installed as standard"
-  },
-  {
     "name": "UKFast",
     "link": "https://ukfast.co.uk/",
     "category": "no",


### PR DESCRIPTION
Hartserver is a defunct webhost. It shut down in 2022, per their website and Facebook page.

https://hartserver.net/

> 2004 - 2022
> Thanks for all the memories! ♥