### PR TITLE
nearlyfreespeech.net has automatic ssl now

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1342,12 +1342,12 @@
   {
     "name": "NearlyFreeSpeech.NET",
     "link": "https://www.nearlyfreespeech.net/",
-    "category": "partial",
-    "tutorial": "https://members.nearlyfreespeech.net/faq?q=SSLCertificates#SSLCertificates",
-    "announcement": "",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "https://members.nearlyfreespeech.net/faq?q=SSLCertificates#SSLCertificates",
     "plan": "",
-    "reviewed": "2019.6.1",
-    "note": "You need to log in to access the tutorial."
+    "reviewed": "2024.12.11",
+    "note": ""
   },
   {
     "name": "Netsite",


### PR DESCRIPTION
as shown in https://members.nearlyfreespeech.net/faq?q=SSLCertificates#SSLCertificates, ssl activation for every customer's website is now completely automatic.