### PR TITLE
Update hosting_providers.json with Neubox.com

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1,5 +1,15 @@
 [
 {
+    "name": "Neubox",
+    "link": "https://www.neubox.com",
+    "category": "full",
+    "tutorial": "",
+    "announcement": "",
+    "plan": "https://neubox.com/hosting/webhosting/",
+    "reviewed": "2025.08.01",
+    "note": "Free & automated SSL for all webhosting and domains"
+    },
+    {
     "name": "Theory7",
     "link": "https://www.theory7.net",
     "category": "full",


### PR DESCRIPTION
Adding my hosting provider Neubox, good service used for 7 years.  I get certs also for subdomains hosted at other IPs