### PR TITLE
Fix up formatting in readme and add some text from wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ If you notice information that’s out of date or incorrect, [submit a pull requ
 - `link` is usually a link to the provider's main page; it's where clicking on the name will go.
 - for `category`, see descriptions [here](https://certbot.eff.org/hosting_providers/).
 - for `full`/`partial` categories, one of the links provided should have evidence of being in that category.
- - only one of `tutorial`, `announcement`, `plan` will show up, in that order.
-  - `partial` should have `tutorial`.
-  - `full` providers shouldn't need a tutorial to turn on https. an exception might include instructions of what to do if something goes wrong and the automatic https doesn't work.
+  - only one of `tutorial`, `announcement`, `plan` will show up, in that order.
+    - `partial` should have `tutorial`.
+    - `full` providers shouldn't need a tutorial to turn on https. an exception might include instructions of what to do if something goes wrong and the automatic https doesn't work.
 - if one provider offers multiple products, either split into two entries or note it in the `note` field.
-- the `note` field is good for things like noting which products have https, or that the site is available only in certain languages. it's not meant for advertising.
+- the `note` field is good for things like noting which products have https, or that the site is available only in certain languages. it's not meant to advertise the hosting provider's site/offerings.
 - all unused fields should be `""`


### PR DESCRIPTION
Fixes https://github.com/certbot/website/issues/845

Text is not yet deleted from https://github.com/certbot/certbot/wiki/Triage-instructions#reviewing-hosting-providers-requests, but it will be the entire first section in "Reviewing hosting providers requests". The second section will remain.