### PR TITLE
Added Webnames.ca to hosting_providers.json

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -2928,5 +2928,15 @@
     "plan": "https://www.kaashosting.nl/web-hosting",
     "reviewed": "2026.04.22",
     "note": "The website is in Dutch."
+  },
+  {
+    "name": "Webnames.ca",
+    "link": "https://www.webnames.ca/",
+    "category": "partial",
+    "tutorial": "https://www.webnames.ca/help/hosting/Content/Resources/Articles/Hosting/Websites_and_Domains/Securing_Your_Websites/LetsEncrypt.htm",
+    "announcement": "",
+    "plan": "",
+    "reviewed": "2026.07.03",
+    "note": ""
   }
 ]


### PR DESCRIPTION
Background: Webnames.ca is a well-known Canadian domain registrar, web hosting, and DNS provider, in operation since 2000 and founded by the original maintainers of the .ca ccTLD. We have supported Let's Encrypt in our shared Plesk hosting platform for several years and would like to add ourselves to your list of supported providers.

Thanks,

Jordan Rieger
Software Development Manager
Webnames.ca Inc.

## Pull Request Checklist

- [ x] I have carefully read and fully understood the instructions in [the README file](https://github.com/certbot/website/blob/master/README.md), and I attest that this pull request conforms to those instructions.
  - [x ] I have placed a link in exactly one of {tutorial, announcement, plan}
  - [x ] If the user must take any additional action to add a certificate, I have set the category to partial
  - [x ] The note field is not a generic description of the offerings; it notes the language, or which products have full support in an otherwise partial provider. Otherwise, it is empty.
