### PR TITLE
Add ZEROLAG to hosting providers list

### DIFF
--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -4,8 +4,8 @@
   "link": "https://zerolag.ro/",
   "category": "full",
   "tutorial": "",
-  "announcement": "",
-  "plan": "https://zerolag.ro/gazduire-web",
+  "announcement": "https://zerolag.ro/gazduire-web",
+  "plan": "",
   "reviewed": "2026.9.1",
   "note": ""
 },

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1,4 +1,14 @@
 [
+    {
+  "name": "ZEROLAG",
+  "link": "https://zerolag.ro/",
+  "category": "full",
+  "tutorial": "",
+  "announcement": "",
+  "plan": "https://zerolag.ro/gazduire-web",
+  "reviewed": "2026.9.1",
+  "note": "Shared, WordPress, and WooCommerce hosting use automatic Let's Encrypt certificates via cPanel AutoSSL."
+},
 {
     "name": "Misk.com",
     "link": "https://www.misk.com/",

--- a/_data/hosting_providers.json
+++ b/_data/hosting_providers.json
@@ -1,5 +1,5 @@
 [
-    {
+{
   "name": "ZEROLAG",
   "link": "https://zerolag.ro/",
   "category": "full",
@@ -7,7 +7,7 @@
   "announcement": "",
   "plan": "https://zerolag.ro/gazduire-web",
   "reviewed": "2026.9.1",
-  "note": "Shared, WordPress, and WooCommerce hosting use automatic Let's Encrypt certificates via cPanel AutoSSL."
+  "note": ""
 },
 {
     "name": "Misk.com",


### PR DESCRIPTION
### Summary

Adds ZEROLAG to the hosting providers list with full HTTPS support.

ZEROLAG provides automatic Let's Encrypt certificates for shared, WordPress, and WooCommerce hosting, with HTTPS enabled automatically for hosted domains.

The ZEROLAG homepage also displays the Let's Encrypt logo among the technologies used by the hosting platform.

Provider:
https://zerolag.ro/

Hosting plans:
https://zerolag.ro/gazduire-web

## Pull Request Checklist

- [x] I have carefully read and fully understood the instructions in [the README file](https://github.com/certbot/website/blob/master/README.md), and I attest that this pull request conforms to those instructions.
  - [x] I have placed a link in exactly one of {tutorial, announcement, plan}
  - [x] If the user must take any additional action to add a certificate, I have set the category to partial
  - [x] The note field is not a generic description of the offerings; it notes the language, or which products have full support in an otherwise partial provider. Otherwise, it is empty.